### PR TITLE
feat: #35 メール件名にバックエンド識別子を追加

### DIFF
--- a/backends/go-gin/internal/infrastructure/mail/mailer.go
+++ b/backends/go-gin/internal/infrastructure/mail/mailer.go
@@ -44,7 +44,7 @@ func (m *Mailer) SendAccessToken(to, clientName, token string) {
 	if to == "" {
 		return
 	}
-	subject := mailSubject(m.cfg.AppEnv, fmt.Sprintf("【%s】アクセストークンのお知らせ", m.cfg.AppName))
+	subject := mailSubject(m.cfg.AppEnv, fmt.Sprintf("【%s / Go】アクセストークンのお知らせ", m.cfg.AppName))
 	body := buildAccessTokenHTML(clientName, token, m.cfg.AppName)
 
 	fromHeader := mime.QEncoding.Encode("UTF-8", m.cfg.AppName) + " <" + m.cfg.FromAddress + ">"

--- a/backends/php-laravel/config/authorization/app.php
+++ b/backends/php-laravel/config/authorization/app.php
@@ -32,7 +32,7 @@ return [
         'port' => env('MAIL_PORT'),
         'from' => env('MAIL_FROM_ADDRESS'),
         'subject' => [
-            'prefix' => '【' . env('APP_NAME') . '】',
+            'prefix' => '【' . env('APP_NAME') . ' / PHP】',
             'access_token' => 'アクセストークンのお知らせ',
         ],
         'template' => [

--- a/backends/python-fastapi/app/infrastructure/mail/mailer.py
+++ b/backends/python-fastapi/app/infrastructure/mail/mailer.py
@@ -26,7 +26,7 @@ def send_access_token(to: str, client_name: str, token: str) -> None:
     if not to:
         return
     settings = get_settings()
-    subject = _mail_subject(settings.app_env, f"【{settings.app_name}】アクセストークンのお知らせ")
+    subject = _mail_subject(settings.app_env, f"【{settings.app_name} / Python】アクセストークンのお知らせ")
     html = _build_html(client_name, token, settings.app_name)
 
     msg = MIMEMultipart("alternative")

--- a/backends/ts-hono/src/infrastructure/mail/mailer.ts
+++ b/backends/ts-hono/src/infrastructure/mail/mailer.ts
@@ -17,7 +17,7 @@ export async function sendAccessToken(to: string, clientName: string, token: str
   if (!to) return;
 
   const { host, port, username, password, fromAddress, appName } = config.mail;
-  const subject = mailSubject(`【${appName}】アクセストークンのお知らせ`);
+  const subject = mailSubject(`【${appName} / TypeScript】アクセストークンのお知らせ`);
   const html = buildHtml(clientName, token, appName);
 
   const transporter = nodemailer.createTransport({


### PR DESCRIPTION
## Summary

- 各バックエンドのメール件名に `/ バックエンド名` を固定文字列として追加
- `.env` 不要、各 mailer に1行ずつ変更

## 変更後の件名

```
【Authorization Gateway / PHP】アクセストークンのお知らせ
【Authorization Gateway / Go】アクセストークンのお知らせ
【Authorization Gateway / Python】アクセストークンのお知らせ
【Authorization Gateway / TypeScript】アクセストークンのお知らせ
```

## Test plan

- [ ] 各バックエンドでクライアント登録し、受信メールの件名にバックエンド名が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)