### PR TITLE
feat(#74): 招待リンクを権限ごとに分ける

### DIFF
--- a/.github/workflows/ruby-rails-ci.yml
+++ b/.github/workflows/ruby-rails-ci.yml
@@ -65,6 +65,14 @@ jobs:
       - name: Load schema
         run: mysql -h 127.0.0.1 -u root -p'docker#DOCKER1234' authorization_test < backends/go-gin/tests/schema.sql
 
+      # schema_migrations テーブルを作成してマイグレーション適用済みを記録
+      - name: Seed schema_migrations
+        run: |
+          mysql -h 127.0.0.1 -u root -p'docker#DOCKER1234' authorization_test -e "
+            CREATE TABLE IF NOT EXISTS \`schema_migrations\` (\`version\` varchar(255) NOT NULL, PRIMARY KEY (\`version\`));
+            INSERT IGNORE INTO \`schema_migrations\` (\`version\`) VALUES ('20260516000000');
+          "
+
       # .env ファイルをコピー
       - name: Generate .env
         run: cp .env.testing .env

--- a/backends/go-beego/internal/domain/invitation/auth_repository.go
+++ b/backends/go-beego/internal/domain/invitation/auth_repository.go
@@ -1,7 +1,7 @@
 package invitation
 
 type AuthRepository interface {
-	Store(token string, ttl int) error
-	Find(token string) (string, error)
+	Store(token string, role int, ttl int) error
+	Find(token string) (*int, error)
 	Remove(token string) error
 }

--- a/backends/go-beego/internal/domain/invitation/entity.go
+++ b/backends/go-beego/internal/domain/invitation/entity.go
@@ -5,6 +5,7 @@ import "time"
 type Invitation struct {
 	ID        uint
 	Token     string
+	Role      int
 	CreatedAt time.Time
 	CreatedBy *uint
 	UpdatedAt time.Time

--- a/backends/go-beego/internal/domain/invitation/repository.go
+++ b/backends/go-beego/internal/domain/invitation/repository.go
@@ -1,7 +1,7 @@
 package invitation
 
 type Repository interface {
-	GetCurrent() (*Vo, error)
-	Issue() (*Vo, error)
+	GetCurrentByRole(role int) (*Vo, error)
+	Issue(role int) (*Vo, error)
 	FindByToken(token string) (*Vo, error)
 }

--- a/backends/go-beego/internal/domain/invitation/value_objects.go
+++ b/backends/go-beego/internal/domain/invitation/value_objects.go
@@ -2,6 +2,7 @@ package invitation
 
 type Vo struct {
 	Token      string
+	Role       int
 	URL        string
 	DisplayURL string
 }

--- a/backends/go-beego/internal/handler/admin_invitation_handler.go
+++ b/backends/go-beego/internal/handler/admin_invitation_handler.go
@@ -4,8 +4,10 @@ import (
 	dominvitation "authorization-go-beego/internal/domain/invitation"
 	"authorization-go-beego/internal/infrastructure/persistence"
 	uinvitation "authorization-go-beego/internal/usecase/invitation"
+	"authorization-go-beego/pkg/apperror"
 	"context"
 	"net/http"
+	"strconv"
 
 	beecontext "github.com/beego/beego/v2/server/web/context"
 	"github.com/beego/beego/v2/client/orm"
@@ -21,7 +23,12 @@ func NewAdminInvitationHandler(ormer orm.Ormer, newInviteUC func(persistence.Que
 }
 
 func (h *AdminInvitationHandler) Index(ctx *beecontext.Context) {
-	result, err := h.newInviteUC(h.ormer).Current()
+	role, ok := parseRoleParam(ctx)
+	if !ok {
+		writeError(ctx, apperror.BadRequest("role_invalid"))
+		return
+	}
+	result, err := h.newInviteUC(h.ormer).Current(role)
 	if err != nil {
 		writeError(ctx, err)
 		return
@@ -30,16 +37,38 @@ func (h *AdminInvitationHandler) Index(ctx *beecontext.Context) {
 }
 
 func (h *AdminInvitationHandler) Issue(ctx *beecontext.Context) {
+	staffID := staffIDFromCookie(ctx)
+	if staffID == 0 {
+		writeError(ctx, apperror.Unauthorized("unauthenticated"))
+		return
+	}
+	role, ok := parseRoleParam(ctx)
+	if !ok {
+		writeError(ctx, apperror.BadRequest("role_invalid"))
+		return
+	}
 	var result *dominvitation.Vo
 	if txErr := h.ormer.DoTx(func(_ context.Context, tx orm.TxOrmer) error {
 		var e error
-		result, e = h.newInviteUC(tx).Issue()
+		result, e = h.newInviteUC(tx).Issue(role)
 		return e
 	}); txErr != nil {
 		writeError(ctx, txErr)
 		return
 	}
 	writeJSON(ctx, http.StatusOK, mapInvitationVo(result))
+}
+
+func parseRoleParam(ctx *beecontext.Context) (int, bool) {
+	raw := ctx.Input.Query("role")
+	if raw == "" {
+		return 2, true
+	}
+	role, err := strconv.Atoi(raw)
+	if err != nil || (role != 1 && role != 2) {
+		return 0, false
+	}
+	return role, true
 }
 
 func mapInvitationVo(v *dominvitation.Vo) map[string]interface{} {

--- a/backends/go-beego/internal/infrastructure/cache/redis_invitation_auth_repository.go
+++ b/backends/go-beego/internal/infrastructure/cache/redis_invitation_auth_repository.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"authorization-go-beego/internal/config"
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -17,18 +18,25 @@ func NewRedisInvitationAuthRepository(rdb *redis.Client, cfg *config.Config) *Re
 	return &RedisInvitationAuthRepository{rdb: rdb, cfg: cfg}
 }
 
-func (r *RedisInvitationAuthRepository) Store(token string, ttl int) error {
+func (r *RedisInvitationAuthRepository) Store(token string, role int, ttl int) error {
 	ctx := context.Background()
-	return r.rdb.Set(ctx, r.key(token), token, time.Duration(ttl)*time.Second).Err()
+	return r.rdb.Set(ctx, r.key(token), strconv.Itoa(role), time.Duration(ttl)*time.Second).Err()
 }
 
-func (r *RedisInvitationAuthRepository) Find(token string) (string, error) {
+func (r *RedisInvitationAuthRepository) Find(token string) (*int, error) {
 	ctx := context.Background()
 	val, err := r.rdb.Get(ctx, r.key(token)).Result()
 	if err == redis.Nil {
-		return "", nil
+		return nil, nil
 	}
-	return val, err
+	if err != nil {
+		return nil, err
+	}
+	role, err := strconv.Atoi(val)
+	if err != nil {
+		return nil, err
+	}
+	return &role, nil
 }
 
 func (r *RedisInvitationAuthRepository) Remove(token string) error {

--- a/backends/go-beego/internal/infrastructure/model/model.go
+++ b/backends/go-beego/internal/infrastructure/model/model.go
@@ -54,6 +54,7 @@ func (s *Staff) TableName() string { return "staffs" }
 type Invitation struct {
 	ID        uint       `orm:"pk;auto;column(id)"`
 	Token     string     `orm:"column(token)"`
+	Role      int        `orm:"column(role)"`
 	CreatedAt time.Time  `orm:"column(created_at)"`
 	CreatedBy *uint      `orm:"column(created_by);null"`
 	UpdatedAt time.Time  `orm:"column(updated_at)"`

--- a/backends/go-beego/internal/infrastructure/persistence/gorm_invitation_repository.go
+++ b/backends/go-beego/internal/infrastructure/persistence/gorm_invitation_repository.go
@@ -21,10 +21,11 @@ func NewOrmInvitationRepository(o QueryOrmer, frontendURL string) *OrmInvitation
 	return &OrmInvitationRepository{o: o, frontendURL: frontendURL}
 }
 
-func (r *OrmInvitationRepository) GetCurrent() (*dominvitation.Vo, error) {
+func (r *OrmInvitationRepository) GetCurrentByRole(role int) (*dominvitation.Vo, error) {
 	var m model.Invitation
 	err := r.o.QueryTable(new(model.Invitation)).
 		Filter("deleted_at__isnull", true).
+		Filter("role", role).
 		OrderBy("-id").
 		One(&m)
 	if err == orm.ErrNoRows {
@@ -33,10 +34,10 @@ func (r *OrmInvitationRepository) GetCurrent() (*dominvitation.Vo, error) {
 	if err != nil {
 		return nil, err
 	}
-	return r.buildVo(m.Token), nil
+	return r.buildVo(m.Token, m.Role), nil
 }
 
-func (r *OrmInvitationRepository) Issue() (*dominvitation.Vo, error) {
+func (r *OrmInvitationRepository) Issue(role int) (*dominvitation.Vo, error) {
 	token, err := generateInvitationToken()
 	if err != nil {
 		return nil, err
@@ -45,6 +46,7 @@ func (r *OrmInvitationRepository) Issue() (*dominvitation.Vo, error) {
 	zero := uint(0)
 	m := model.Invitation{
 		Token:     token,
+		Role:      role,
 		CreatedAt: now,
 		CreatedBy: &zero,
 		UpdatedAt: now,
@@ -53,7 +55,7 @@ func (r *OrmInvitationRepository) Issue() (*dominvitation.Vo, error) {
 	if _, err = r.o.Insert(&m); err != nil {
 		return nil, err
 	}
-	return r.buildVo(token), nil
+	return r.buildVo(token, role), nil
 }
 
 func (r *OrmInvitationRepository) FindByToken(token string) (*dominvitation.Vo, error) {
@@ -68,12 +70,12 @@ func (r *OrmInvitationRepository) FindByToken(token string) (*dominvitation.Vo, 
 	if err != nil {
 		return nil, err
 	}
-	return r.buildVo(m.Token), nil
+	return r.buildVo(m.Token, m.Role), nil
 }
 
-func (r *OrmInvitationRepository) buildVo(token string) *dominvitation.Vo {
+func (r *OrmInvitationRepository) buildVo(token string, role int) *dominvitation.Vo {
 	url := fmt.Sprintf("%s/invitation/%s", r.frontendURL, token)
-	return &dominvitation.Vo{Token: token, URL: url, DisplayURL: buildDisplayURL(url)}
+	return &dominvitation.Vo{Token: token, Role: role, URL: url, DisplayURL: buildDisplayURL(url)}
 }
 
 func buildDisplayURL(url string) string {

--- a/backends/go-beego/internal/usecase/auth/interactor.go
+++ b/backends/go-beego/internal/usecase/auth/interactor.go
@@ -43,15 +43,20 @@ func (uc *Interactor) Login(dto LoginDto) (*domstaff.Vo, error) {
 		if dto.InvitationToken == "" {
 			return nil, apperror.Forbidden("invitation_required")
 		}
-		found, err := uc.invitationAuthRepo.Find(dto.InvitationToken)
+		foundRole, err := uc.invitationAuthRepo.Find(dto.InvitationToken)
 		if err != nil {
 			return nil, err
 		}
-		if found == "" {
+		if foundRole == nil {
 			return nil, apperror.Forbidden("invitation_required")
 		}
 		if err := uc.invitationAuthRepo.Remove(dto.InvitationToken); err != nil {
 			return nil, err
+		}
+
+		role := *foundRole
+		if role != domstaff.RoleAdmin && role != domstaff.RoleMember {
+			role = domstaff.RoleMember
 		}
 
 		zero := uint(0)
@@ -61,7 +66,7 @@ func (uc *Interactor) Login(dto LoginDto) (*domstaff.Vo, error) {
 			Provider:    dto.Provider,
 			ProviderID:  dto.ProviderID,
 			Avatar:      dto.Avatar,
-			Role:        domstaff.RoleMember,
+			Role:        role,
 			LastLoginAt: &now,
 			CreatedAt:   now,
 			CreatedBy:   &zero,

--- a/backends/go-beego/internal/usecase/invitation/interactor.go
+++ b/backends/go-beego/internal/usecase/invitation/interactor.go
@@ -14,8 +14,8 @@ func NewInteractor(repo dominvitation.Repository, authRepo dominvitation.AuthRep
 	return &Interactor{repo: repo, authRepo: authRepo}
 }
 
-func (uc *Interactor) Current() (*dominvitation.Vo, error) {
-	result, err := uc.repo.GetCurrent()
+func (uc *Interactor) Current(role int) (*dominvitation.Vo, error) {
+	result, err := uc.repo.GetCurrentByRole(role)
 	if err != nil {
 		return nil, err
 	}
@@ -25,8 +25,8 @@ func (uc *Interactor) Current() (*dominvitation.Vo, error) {
 	return result, nil
 }
 
-func (uc *Interactor) Issue() (*dominvitation.Vo, error) {
-	return uc.repo.Issue()
+func (uc *Interactor) Issue(role int) (*dominvitation.Vo, error) {
+	return uc.repo.Issue(role)
 }
 
 func (uc *Interactor) FindByToken(dto FindByTokenDto) (*dominvitation.Vo, error) {
@@ -40,7 +40,7 @@ func (uc *Interactor) FindByToken(dto FindByTokenDto) (*dominvitation.Vo, error)
 	if result == nil {
 		return nil, apperror.BadRequest("invitation_invalid")
 	}
-	if err := uc.authRepo.Store(result.Token, 600); err != nil {
+	if err := uc.authRepo.Store(result.Token, result.Role, 600); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/backends/go-beego/tests/schema.sql
+++ b/backends/go-beego/tests/schema.sql
@@ -63,6 +63,7 @@ CREATE TABLE `clients` (
 CREATE TABLE `invitations` (
     `id`            INT UNSIGNED    NOT NULL AUTO_INCREMENT,
     `token`         VARCHAR(255)    NOT NULL,
+    `role`          INT UNSIGNED    NOT NULL DEFAULT 2,
     `created_at`    TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `created_by`    INT UNSIGNED,
     `updated_at`    TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/backends/go-beego/tests/setup_test.go
+++ b/backends/go-beego/tests/setup_test.go
@@ -294,11 +294,16 @@ func createClient(t *testing.T, overrides map[string]interface{}) *model.Client 
 	return c
 }
 
-func createInvitation(t *testing.T, token string) *model.Invitation {
+func createInvitation(t *testing.T, token string, role ...int) *model.Invitation {
 	t.Helper()
+	r := 2
+	if len(role) > 0 {
+		r = role[0]
+	}
 	now := time.Now()
 	inv := &model.Invitation{
 		Token:     token,
+		Role:      r,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}

--- a/backends/go-echo/ent/invitation.go
+++ b/backends/go-echo/ent/invitation.go
@@ -19,6 +19,8 @@ type Invitation struct {
 	ID uint `json:"id,omitempty"`
 	// Token holds the value of the "token" field.
 	Token string `json:"token,omitempty"`
+	// Role holds the value of the "role" field.
+	Role int `json:"role,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// CreatedBy holds the value of the "created_by" field.
@@ -41,7 +43,7 @@ func (*Invitation) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case invitation.FieldID, invitation.FieldCreatedBy, invitation.FieldUpdatedBy, invitation.FieldDeletedBy, invitation.FieldVersion:
+		case invitation.FieldID, invitation.FieldRole, invitation.FieldCreatedBy, invitation.FieldUpdatedBy, invitation.FieldDeletedBy, invitation.FieldVersion:
 			values[i] = new(sql.NullInt64)
 		case invitation.FieldToken:
 			values[i] = new(sql.NullString)
@@ -73,6 +75,12 @@ func (_m *Invitation) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field token", values[i])
 			} else if value.Valid {
 				_m.Token = value.String
+			}
+		case invitation.FieldRole:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field role", values[i])
+			} else if value.Valid {
+				_m.Role = int(value.Int64)
 			}
 		case invitation.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -158,6 +166,9 @@ func (_m *Invitation) String() string {
 	builder.WriteString(fmt.Sprintf("id=%v, ", _m.ID))
 	builder.WriteString("token=")
 	builder.WriteString(_m.Token)
+	builder.WriteString(", ")
+	builder.WriteString("role=")
+	builder.WriteString(fmt.Sprintf("%v", _m.Role))
 	builder.WriteString(", ")
 	builder.WriteString("created_at=")
 	builder.WriteString(_m.CreatedAt.Format(time.ANSIC))

--- a/backends/go-echo/ent/invitation/invitation.go
+++ b/backends/go-echo/ent/invitation/invitation.go
@@ -15,6 +15,8 @@ const (
 	FieldID = "id"
 	// FieldToken holds the string denoting the token field in the database.
 	FieldToken = "token"
+	// FieldRole holds the string denoting the role field in the database.
+	FieldRole = "role"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
 	FieldCreatedAt = "created_at"
 	// FieldCreatedBy holds the string denoting the created_by field in the database.
@@ -37,6 +39,7 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldToken,
+	FieldRole,
 	FieldCreatedAt,
 	FieldCreatedBy,
 	FieldUpdatedAt,
@@ -57,6 +60,8 @@ func ValidColumn(column string) bool {
 }
 
 var (
+	// DefaultRole holds the default value on creation for the "role" field.
+	DefaultRole int
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -78,6 +83,11 @@ func ByID(opts ...sql.OrderTermOption) OrderOption {
 // ByToken orders the results by the token field.
 func ByToken(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldToken, opts...).ToFunc()
+}
+
+// ByRole orders the results by the role field.
+func ByRole(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRole, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.

--- a/backends/go-echo/ent/invitation/where.go
+++ b/backends/go-echo/ent/invitation/where.go
@@ -59,6 +59,51 @@ func Token(v string) predicate.Invitation {
 	return predicate.Invitation(sql.FieldEQ(FieldToken, v))
 }
 
+// Role applies equality check predicate on the "role" field. It's identical to RoleEQ.
+func Role(v int) predicate.Invitation {
+	return predicate.Invitation(sql.FieldEQ(FieldRole, v))
+}
+
+// RoleEQ applies the EQ predicate on the "role" field.
+func RoleEQ(v int) predicate.Invitation {
+	return predicate.Invitation(sql.FieldEQ(FieldRole, v))
+}
+
+// RoleNEQ applies the NEQ predicate on the "role" field.
+func RoleNEQ(v int) predicate.Invitation {
+	return predicate.Invitation(sql.FieldNEQ(FieldRole, v))
+}
+
+// RoleIn applies the In predicate on the "role" field.
+func RoleIn(vs ...int) predicate.Invitation {
+	return predicate.Invitation(sql.FieldIn(FieldRole, vs...))
+}
+
+// RoleNotIn applies the NotIn predicate on the "role" field.
+func RoleNotIn(vs ...int) predicate.Invitation {
+	return predicate.Invitation(sql.FieldNotIn(FieldRole, vs...))
+}
+
+// RoleGT applies the GT predicate on the "role" field.
+func RoleGT(v int) predicate.Invitation {
+	return predicate.Invitation(sql.FieldGT(FieldRole, v))
+}
+
+// RoleGTE applies the GTE predicate on the "role" field.
+func RoleGTE(v int) predicate.Invitation {
+	return predicate.Invitation(sql.FieldGTE(FieldRole, v))
+}
+
+// RoleLT applies the LT predicate on the "role" field.
+func RoleLT(v int) predicate.Invitation {
+	return predicate.Invitation(sql.FieldLT(FieldRole, v))
+}
+
+// RoleLTE applies the LTE predicate on the "role" field.
+func RoleLTE(v int) predicate.Invitation {
+	return predicate.Invitation(sql.FieldLTE(FieldRole, v))
+}
+
 // CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.
 func CreatedAt(v time.Time) predicate.Invitation {
 	return predicate.Invitation(sql.FieldEQ(FieldCreatedAt, v))

--- a/backends/go-echo/ent/invitation_create.go
+++ b/backends/go-echo/ent/invitation_create.go
@@ -26,6 +26,20 @@ func (_c *InvitationCreate) SetToken(v string) *InvitationCreate {
 	return _c
 }
 
+// SetRole sets the "role" field.
+func (_c *InvitationCreate) SetRole(v int) *InvitationCreate {
+	_c.mutation.SetRole(v)
+	return _c
+}
+
+// SetNillableRole sets the "role" field if the given value is not nil.
+func (_c *InvitationCreate) SetNillableRole(v *int) *InvitationCreate {
+	if v != nil {
+		_c.SetRole(*v)
+	}
+	return _c
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_c *InvitationCreate) SetCreatedAt(v time.Time) *InvitationCreate {
 	_c.mutation.SetCreatedAt(v)
@@ -165,6 +179,10 @@ func (_c *InvitationCreate) ExecX(ctx context.Context) {
 
 // defaults sets the default values of the builder before save.
 func (_c *InvitationCreate) defaults() {
+	if _, ok := _c.mutation.Role(); !ok {
+		v := invitation.DefaultRole
+		_c.mutation.SetRole(v)
+	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
 		v := invitation.DefaultCreatedAt()
 		_c.mutation.SetCreatedAt(v)
@@ -183,6 +201,9 @@ func (_c *InvitationCreate) defaults() {
 func (_c *InvitationCreate) check() error {
 	if _, ok := _c.mutation.Token(); !ok {
 		return &ValidationError{Name: "token", err: errors.New(`ent: missing required field "Invitation.token"`)}
+	}
+	if _, ok := _c.mutation.Role(); !ok {
+		return &ValidationError{Name: "role", err: errors.New(`ent: missing required field "Invitation.role"`)}
 	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "Invitation.created_at"`)}
@@ -233,6 +254,10 @@ func (_c *InvitationCreate) createSpec() (*Invitation, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.Token(); ok {
 		_spec.SetField(invitation.FieldToken, field.TypeString, value)
 		_node.Token = value
+	}
+	if value, ok := _c.mutation.Role(); ok {
+		_spec.SetField(invitation.FieldRole, field.TypeInt, value)
+		_node.Role = value
 	}
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(invitation.FieldCreatedAt, field.TypeTime, value)

--- a/backends/go-echo/ent/invitation_update.go
+++ b/backends/go-echo/ent/invitation_update.go
@@ -42,6 +42,27 @@ func (_u *InvitationUpdate) SetNillableToken(v *string) *InvitationUpdate {
 	return _u
 }
 
+// SetRole sets the "role" field.
+func (_u *InvitationUpdate) SetRole(v int) *InvitationUpdate {
+	_u.mutation.ResetRole()
+	_u.mutation.SetRole(v)
+	return _u
+}
+
+// SetNillableRole sets the "role" field if the given value is not nil.
+func (_u *InvitationUpdate) SetNillableRole(v *int) *InvitationUpdate {
+	if v != nil {
+		_u.SetRole(*v)
+	}
+	return _u
+}
+
+// AddRole adds v to the "role" field.
+func (_u *InvitationUpdate) AddRole(v int) *InvitationUpdate {
+	_u.mutation.AddRole(v)
+	return _u
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_u *InvitationUpdate) SetCreatedAt(v time.Time) *InvitationUpdate {
 	_u.mutation.SetCreatedAt(v)
@@ -236,6 +257,12 @@ func (_u *InvitationUpdate) sqlSave(ctx context.Context) (_node int, err error) 
 	if value, ok := _u.mutation.Token(); ok {
 		_spec.SetField(invitation.FieldToken, field.TypeString, value)
 	}
+	if value, ok := _u.mutation.Role(); ok {
+		_spec.SetField(invitation.FieldRole, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedRole(); ok {
+		_spec.AddField(invitation.FieldRole, field.TypeInt, value)
+	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(invitation.FieldCreatedAt, field.TypeTime, value)
 	}
@@ -312,6 +339,27 @@ func (_u *InvitationUpdateOne) SetNillableToken(v *string) *InvitationUpdateOne 
 	if v != nil {
 		_u.SetToken(*v)
 	}
+	return _u
+}
+
+// SetRole sets the "role" field.
+func (_u *InvitationUpdateOne) SetRole(v int) *InvitationUpdateOne {
+	_u.mutation.ResetRole()
+	_u.mutation.SetRole(v)
+	return _u
+}
+
+// SetNillableRole sets the "role" field if the given value is not nil.
+func (_u *InvitationUpdateOne) SetNillableRole(v *int) *InvitationUpdateOne {
+	if v != nil {
+		_u.SetRole(*v)
+	}
+	return _u
+}
+
+// AddRole adds v to the "role" field.
+func (_u *InvitationUpdateOne) AddRole(v int) *InvitationUpdateOne {
+	_u.mutation.AddRole(v)
 	return _u
 }
 
@@ -538,6 +586,12 @@ func (_u *InvitationUpdateOne) sqlSave(ctx context.Context) (_node *Invitation, 
 	}
 	if value, ok := _u.mutation.Token(); ok {
 		_spec.SetField(invitation.FieldToken, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.Role(); ok {
+		_spec.SetField(invitation.FieldRole, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedRole(); ok {
+		_spec.AddField(invitation.FieldRole, field.TypeInt, value)
 	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(invitation.FieldCreatedAt, field.TypeTime, value)

--- a/backends/go-echo/ent/migrate/schema.go
+++ b/backends/go-echo/ent/migrate/schema.go
@@ -46,6 +46,7 @@ var (
 	InvitationsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeUint, Increment: true},
 		{Name: "token", Type: field.TypeString},
+		{Name: "role", Type: field.TypeInt, Default: 2},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "created_by", Type: field.TypeUint, Nullable: true},
 		{Name: "updated_at", Type: field.TypeTime},

--- a/backends/go-echo/ent/mutation.go
+++ b/backends/go-echo/ent/mutation.go
@@ -1981,6 +1981,8 @@ type InvitationMutation struct {
 	typ           string
 	id            *uint
 	token         *string
+	role          *int
+	addrole       *int
 	created_at    *time.Time
 	created_by    *uint
 	addcreated_by *int
@@ -2136,6 +2138,62 @@ func (m *InvitationMutation) OldToken(ctx context.Context) (v string, err error)
 // ResetToken resets all changes to the "token" field.
 func (m *InvitationMutation) ResetToken() {
 	m.token = nil
+}
+
+// SetRole sets the "role" field.
+func (m *InvitationMutation) SetRole(i int) {
+	m.role = &i
+	m.addrole = nil
+}
+
+// Role returns the value of the "role" field in the mutation.
+func (m *InvitationMutation) Role() (r int, exists bool) {
+	v := m.role
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRole returns the old "role" field's value of the Invitation entity.
+// If the Invitation object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *InvitationMutation) OldRole(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRole is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRole requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRole: %w", err)
+	}
+	return oldValue.Role, nil
+}
+
+// AddRole adds i to the "role" field.
+func (m *InvitationMutation) AddRole(i int) {
+	if m.addrole != nil {
+		*m.addrole += i
+	} else {
+		m.addrole = &i
+	}
+}
+
+// AddedRole returns the value that was added to the "role" field in this mutation.
+func (m *InvitationMutation) AddedRole() (r int, exists bool) {
+	v := m.addrole
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetRole resets all changes to the "role" field.
+func (m *InvitationMutation) ResetRole() {
+	m.role = nil
+	m.addrole = nil
 }
 
 // SetCreatedAt sets the "created_at" field.
@@ -2559,9 +2617,12 @@ func (m *InvitationMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *InvitationMutation) Fields() []string {
-	fields := make([]string, 0, 8)
+	fields := make([]string, 0, 9)
 	if m.token != nil {
 		fields = append(fields, invitation.FieldToken)
+	}
+	if m.role != nil {
+		fields = append(fields, invitation.FieldRole)
 	}
 	if m.created_at != nil {
 		fields = append(fields, invitation.FieldCreatedAt)
@@ -2594,6 +2655,8 @@ func (m *InvitationMutation) Field(name string) (ent.Value, bool) {
 	switch name {
 	case invitation.FieldToken:
 		return m.Token()
+	case invitation.FieldRole:
+		return m.Role()
 	case invitation.FieldCreatedAt:
 		return m.CreatedAt()
 	case invitation.FieldCreatedBy:
@@ -2619,6 +2682,8 @@ func (m *InvitationMutation) OldField(ctx context.Context, name string) (ent.Val
 	switch name {
 	case invitation.FieldToken:
 		return m.OldToken(ctx)
+	case invitation.FieldRole:
+		return m.OldRole(ctx)
 	case invitation.FieldCreatedAt:
 		return m.OldCreatedAt(ctx)
 	case invitation.FieldCreatedBy:
@@ -2648,6 +2713,13 @@ func (m *InvitationMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetToken(v)
+		return nil
+	case invitation.FieldRole:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRole(v)
 		return nil
 	case invitation.FieldCreatedAt:
 		v, ok := value.(time.Time)
@@ -2706,6 +2778,9 @@ func (m *InvitationMutation) SetField(name string, value ent.Value) error {
 // this mutation.
 func (m *InvitationMutation) AddedFields() []string {
 	var fields []string
+	if m.addrole != nil {
+		fields = append(fields, invitation.FieldRole)
+	}
 	if m.addcreated_by != nil {
 		fields = append(fields, invitation.FieldCreatedBy)
 	}
@@ -2726,6 +2801,8 @@ func (m *InvitationMutation) AddedFields() []string {
 // was not set, or was not defined in the schema.
 func (m *InvitationMutation) AddedField(name string) (ent.Value, bool) {
 	switch name {
+	case invitation.FieldRole:
+		return m.AddedRole()
 	case invitation.FieldCreatedBy:
 		return m.AddedCreatedBy()
 	case invitation.FieldUpdatedBy:
@@ -2743,6 +2820,13 @@ func (m *InvitationMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *InvitationMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case invitation.FieldRole:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddRole(v)
+		return nil
 	case invitation.FieldCreatedBy:
 		v, ok := value.(int)
 		if !ok {
@@ -2827,6 +2911,9 @@ func (m *InvitationMutation) ResetField(name string) error {
 	switch name {
 	case invitation.FieldToken:
 		m.ResetToken()
+		return nil
+	case invitation.FieldRole:
+		m.ResetRole()
 		return nil
 	case invitation.FieldCreatedAt:
 		m.ResetCreatedAt()

--- a/backends/go-echo/ent/runtime.go
+++ b/backends/go-echo/ent/runtime.go
@@ -39,16 +39,20 @@ func init() {
 	appclient.IDValidator = appclientDescID.Validators[0].(func(uint64) error)
 	invitationFields := schema.Invitation{}.Fields()
 	_ = invitationFields
+	// invitationDescRole is the schema descriptor for role field.
+	invitationDescRole := invitationFields[2].Descriptor()
+	// invitation.DefaultRole holds the default value on creation for the role field.
+	invitation.DefaultRole = invitationDescRole.Default.(int)
 	// invitationDescCreatedAt is the schema descriptor for created_at field.
-	invitationDescCreatedAt := invitationFields[2].Descriptor()
+	invitationDescCreatedAt := invitationFields[3].Descriptor()
 	// invitation.DefaultCreatedAt holds the default value on creation for the created_at field.
 	invitation.DefaultCreatedAt = invitationDescCreatedAt.Default.(func() time.Time)
 	// invitationDescUpdatedAt is the schema descriptor for updated_at field.
-	invitationDescUpdatedAt := invitationFields[4].Descriptor()
+	invitationDescUpdatedAt := invitationFields[5].Descriptor()
 	// invitation.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	invitation.DefaultUpdatedAt = invitationDescUpdatedAt.Default.(func() time.Time)
 	// invitationDescVersion is the schema descriptor for version field.
-	invitationDescVersion := invitationFields[8].Descriptor()
+	invitationDescVersion := invitationFields[9].Descriptor()
 	// invitation.DefaultVersion holds the default value on creation for the version field.
 	invitation.DefaultVersion = invitationDescVersion.Default.(int)
 	// invitationDescID is the schema descriptor for id field.

--- a/backends/go-echo/ent/schema/invitation.go
+++ b/backends/go-echo/ent/schema/invitation.go
@@ -23,6 +23,7 @@ func (Invitation) Fields() []ent.Field {
 	return []ent.Field{
 		field.Uint("id").Positive().Immutable(),
 		field.String("token"),
+		field.Int("role").Default(2),
 		field.Time("created_at").Default(time.Now),
 		field.Uint("created_by").Optional().Nillable(),
 		field.Time("updated_at").Default(time.Now),

--- a/backends/go-echo/internal/domain/invitation/auth_repository.go
+++ b/backends/go-echo/internal/domain/invitation/auth_repository.go
@@ -1,7 +1,7 @@
 package invitation
 
 type AuthRepository interface {
-	Store(token string, ttl int) error
-	Find(token string) (string, error)
+	Store(token string, role int, ttl int) error
+	Find(token string) (*int, error)
 	Remove(token string) error
 }

--- a/backends/go-echo/internal/domain/invitation/entity.go
+++ b/backends/go-echo/internal/domain/invitation/entity.go
@@ -5,6 +5,7 @@ import "time"
 type Invitation struct {
 	ID        uint
 	Token     string
+	Role      int
 	CreatedAt time.Time
 	CreatedBy *uint
 	UpdatedAt time.Time

--- a/backends/go-echo/internal/domain/invitation/repository.go
+++ b/backends/go-echo/internal/domain/invitation/repository.go
@@ -1,7 +1,7 @@
 package invitation
 
 type Repository interface {
-	GetCurrent() (*Vo, error)
-	Issue() (*Vo, error)
+	GetCurrentByRole(role int) (*Vo, error)
+	IssueByRole(role int) (*Vo, error)
 	FindByToken(token string) (*Vo, error)
 }

--- a/backends/go-echo/internal/domain/invitation/value_objects.go
+++ b/backends/go-echo/internal/domain/invitation/value_objects.go
@@ -2,6 +2,7 @@ package invitation
 
 type Vo struct {
 	Token      string
+	Role       int
 	URL        string
 	DisplayURL string
 }

--- a/backends/go-echo/internal/handler/admin_invitation_handler.go
+++ b/backends/go-echo/internal/handler/admin_invitation_handler.go
@@ -4,7 +4,9 @@ import (
 	"authorization-go-echo/ent"
 	dominvitation "authorization-go-echo/internal/domain/invitation"
 	uinvitation "authorization-go-echo/internal/usecase/invitation"
+	"authorization-go-echo/pkg/apperror"
 	"net/http"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 )
@@ -19,7 +21,11 @@ func NewAdminInvitationHandler(db *ent.Client, newInviteUC func(*ent.Client) *ui
 }
 
 func (h *AdminInvitationHandler) Index(c echo.Context) error {
-	result, err := h.newInviteUC(h.db).Current()
+	role, err := parseInvitationRole(c)
+	if err != nil {
+		return err
+	}
+	result, err := h.newInviteUC(h.db).Current(uinvitation.CurrentDto{Role: role})
 	if err != nil {
 		return err
 	}
@@ -27,10 +33,14 @@ func (h *AdminInvitationHandler) Index(c echo.Context) error {
 }
 
 func (h *AdminInvitationHandler) Issue(c echo.Context) error {
+	role, err := parseInvitationRole(c)
+	if err != nil {
+		return err
+	}
 	var result *dominvitation.Vo
 	if txErr := withTx(c.Request().Context(), h.db, func(tx *ent.Tx) error {
 		var e error
-		result, e = h.newInviteUC(tx.Client()).Issue()
+		result, e = h.newInviteUC(tx.Client()).Issue(uinvitation.IssueDto{Role: role})
 		return e
 	}); txErr != nil {
 		return txErr
@@ -38,8 +48,20 @@ func (h *AdminInvitationHandler) Issue(c echo.Context) error {
 	return c.JSON(http.StatusOK, mapInvitationVo(result))
 }
 
+func parseInvitationRole(c echo.Context) (int, error) {
+	roleParam := c.QueryParam("role")
+	if roleParam == "" {
+		return 2, nil
+	}
+	role, err := strconv.Atoi(roleParam)
+	if err != nil || (role != 1 && role != 2) {
+		return 0, apperror.BadRequest("invalid_role")
+	}
+	return role, nil
+}
+
 func mapInvitationVo(v *dominvitation.Vo) map[string]interface{} {
 	return map[string]interface{}{
-		"found": true, "url": v.URL, "display_url": v.DisplayURL, "token": v.Token,
+		"found": true, "url": v.URL, "display_url": v.DisplayURL, "token": v.Token, "role": v.Role,
 	}
 }

--- a/backends/go-echo/internal/infrastructure/cache/redis_invitation_auth_repository.go
+++ b/backends/go-echo/internal/infrastructure/cache/redis_invitation_auth_repository.go
@@ -3,6 +3,8 @@ package cache
 import (
 	"authorization-go-echo/internal/config"
 	"context"
+	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -17,18 +19,25 @@ func NewRedisInvitationAuthRepository(rdb *redis.Client, cfg *config.Config) *Re
 	return &RedisInvitationAuthRepository{rdb: rdb, cfg: cfg}
 }
 
-func (r *RedisInvitationAuthRepository) Store(token string, ttl int) error {
+func (r *RedisInvitationAuthRepository) Store(token string, role int, ttl int) error {
 	ctx := context.Background()
-	return r.rdb.Set(ctx, r.key(token), token, time.Duration(ttl)*time.Second).Err()
+	return r.rdb.Set(ctx, r.key(token), fmt.Sprintf("%d", role), time.Duration(ttl)*time.Second).Err()
 }
 
-func (r *RedisInvitationAuthRepository) Find(token string) (string, error) {
+func (r *RedisInvitationAuthRepository) Find(token string) (*int, error) {
 	ctx := context.Background()
 	val, err := r.rdb.Get(ctx, r.key(token)).Result()
 	if err == redis.Nil {
-		return "", nil
+		return nil, nil
 	}
-	return val, err
+	if err != nil {
+		return nil, err
+	}
+	role, err := strconv.Atoi(val)
+	if err != nil {
+		return nil, err
+	}
+	return &role, nil
 }
 
 func (r *RedisInvitationAuthRepository) Remove(token string) error {

--- a/backends/go-echo/internal/infrastructure/persistence/ent_invitation_repository.go
+++ b/backends/go-echo/internal/infrastructure/persistence/ent_invitation_repository.go
@@ -21,8 +21,9 @@ func NewEntInvitationRepository(db *ent.Client, frontendURL string) *EntInvitati
 	return &EntInvitationRepository{db: db, frontendURL: frontendURL}
 }
 
-func (r *EntInvitationRepository) GetCurrent() (*dominvitation.Vo, error) {
+func (r *EntInvitationRepository) GetCurrentByRole(role int) (*dominvitation.Vo, error) {
 	m, err := r.db.Invitation.Query().
+		Where(invitation.RoleEQ(role), invitation.DeletedAtIsNil()).
 		Order(ent.Desc(invitation.FieldID)).
 		First(context.Background())
 	if err != nil {
@@ -31,10 +32,10 @@ func (r *EntInvitationRepository) GetCurrent() (*dominvitation.Vo, error) {
 		}
 		return nil, err
 	}
-	return r.buildVo(m.Token), nil
+	return r.buildVo(m.Token, m.Role), nil
 }
 
-func (r *EntInvitationRepository) Issue() (*dominvitation.Vo, error) {
+func (r *EntInvitationRepository) IssueByRole(role int) (*dominvitation.Vo, error) {
 	token, err := generateEntInvitationToken()
 	if err != nil {
 		return nil, err
@@ -43,6 +44,7 @@ func (r *EntInvitationRepository) Issue() (*dominvitation.Vo, error) {
 	zero := uint(0)
 	_, err = r.db.Invitation.Create().
 		SetToken(token).
+		SetRole(role).
 		SetCreatedAt(now).
 		SetCreatedBy(zero).
 		SetUpdatedAt(now).
@@ -51,7 +53,7 @@ func (r *EntInvitationRepository) Issue() (*dominvitation.Vo, error) {
 	if err != nil {
 		return nil, err
 	}
-	return r.buildVo(token), nil
+	return r.buildVo(token, role), nil
 }
 
 func (r *EntInvitationRepository) FindByToken(token string) (*dominvitation.Vo, error) {
@@ -64,12 +66,12 @@ func (r *EntInvitationRepository) FindByToken(token string) (*dominvitation.Vo, 
 		}
 		return nil, err
 	}
-	return r.buildVo(m.Token), nil
+	return r.buildVo(m.Token, m.Role), nil
 }
 
-func (r *EntInvitationRepository) buildVo(token string) *dominvitation.Vo {
+func (r *EntInvitationRepository) buildVo(token string, role int) *dominvitation.Vo {
 	url := fmt.Sprintf("%s/invitation/%s", r.frontendURL, token)
-	return &dominvitation.Vo{Token: token, URL: url, DisplayURL: buildEntDisplayURL(url)}
+	return &dominvitation.Vo{Token: token, Role: role, URL: url, DisplayURL: buildEntDisplayURL(url)}
 }
 
 func buildEntDisplayURL(url string) string {

--- a/backends/go-echo/internal/usecase/auth/interactor.go
+++ b/backends/go-echo/internal/usecase/auth/interactor.go
@@ -43,11 +43,11 @@ func (uc *Interactor) Login(dto LoginDto) (*domstaff.Vo, error) {
 		if dto.InvitationToken == "" {
 			return nil, apperror.Forbidden("invitation_required")
 		}
-		found, err := uc.invitationAuthRepo.Find(dto.InvitationToken)
+		rolePtr, err := uc.invitationAuthRepo.Find(dto.InvitationToken)
 		if err != nil {
 			return nil, err
 		}
-		if found == "" {
+		if rolePtr == nil {
 			return nil, apperror.Forbidden("invitation_required")
 		}
 		if err := uc.invitationAuthRepo.Remove(dto.InvitationToken); err != nil {
@@ -61,7 +61,7 @@ func (uc *Interactor) Login(dto LoginDto) (*domstaff.Vo, error) {
 			Provider:    dto.Provider,
 			ProviderID:  dto.ProviderID,
 			Avatar:      dto.Avatar,
-			Role:        domstaff.RoleMember,
+			Role:        *rolePtr,
 			LastLoginAt: &now,
 			CreatedAt:   now,
 			CreatedBy:   &zero,

--- a/backends/go-echo/internal/usecase/invitation/dto.go
+++ b/backends/go-echo/internal/usecase/invitation/dto.go
@@ -3,3 +3,11 @@ package invitation
 type FindByTokenDto struct {
 	Token string
 }
+
+type CurrentDto struct {
+	Role int
+}
+
+type IssueDto struct {
+	Role int
+}

--- a/backends/go-echo/internal/usecase/invitation/interactor.go
+++ b/backends/go-echo/internal/usecase/invitation/interactor.go
@@ -14,8 +14,8 @@ func NewInteractor(repo dominvitation.Repository, authRepo dominvitation.AuthRep
 	return &Interactor{repo: repo, authRepo: authRepo}
 }
 
-func (uc *Interactor) Current() (*dominvitation.Vo, error) {
-	result, err := uc.repo.GetCurrent()
+func (uc *Interactor) Current(dto CurrentDto) (*dominvitation.Vo, error) {
+	result, err := uc.repo.GetCurrentByRole(dto.Role)
 	if err != nil {
 		return nil, err
 	}
@@ -25,8 +25,8 @@ func (uc *Interactor) Current() (*dominvitation.Vo, error) {
 	return result, nil
 }
 
-func (uc *Interactor) Issue() (*dominvitation.Vo, error) {
-	return uc.repo.Issue()
+func (uc *Interactor) Issue(dto IssueDto) (*dominvitation.Vo, error) {
+	return uc.repo.IssueByRole(dto.Role)
 }
 
 func (uc *Interactor) FindByToken(dto FindByTokenDto) (*dominvitation.Vo, error) {
@@ -40,7 +40,7 @@ func (uc *Interactor) FindByToken(dto FindByTokenDto) (*dominvitation.Vo, error)
 	if result == nil {
 		return nil, apperror.BadRequest("invitation_invalid")
 	}
-	if err := uc.authRepo.Store(result.Token, 600); err != nil {
+	if err := uc.authRepo.Store(result.Token, result.Role, 600); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/backends/go-echo/tests/schema.sql
+++ b/backends/go-echo/tests/schema.sql
@@ -63,6 +63,7 @@ CREATE TABLE `clients` (
 CREATE TABLE `invitations` (
     `id`            INT UNSIGNED    NOT NULL AUTO_INCREMENT,
     `token`         VARCHAR(255)    NOT NULL,
+    `role`          INT UNSIGNED    NOT NULL DEFAULT 2,
     `created_at`    TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `created_by`    INT UNSIGNED,
     `updated_at`    TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/backends/go-gin/internal/domain/invitation/auth_repository.go
+++ b/backends/go-gin/internal/domain/invitation/auth_repository.go
@@ -3,10 +3,10 @@ package invitation
 
 // AuthRepository は招待認証トークンのキャッシュインターフェースです。
 type AuthRepository interface {
-	// Store はトークンを指定秒数キャッシュします。
-	Store(token string, ttl int) error
-	// Find はトークンを取得します。存在しない場合は空文字を返します。
-	Find(token string) (string, error)
+	// Store はトークンとロールを指定秒数キャッシュします。
+	Store(token string, role int, ttl int) error
+	// Find はキャッシュからロールを取得します。存在しない場合は nil を返します。
+	Find(token string) (*int, error)
 	// Remove はトークンを削除します。
 	Remove(token string) error
 }

--- a/backends/go-gin/internal/domain/invitation/entity.go
+++ b/backends/go-gin/internal/domain/invitation/entity.go
@@ -6,6 +6,7 @@ import "time"
 type Invitation struct {
 	ID        uint
 	Token     string
+	Role      int
 	CreatedAt time.Time
 	CreatedBy *uint
 	UpdatedAt time.Time

--- a/backends/go-gin/internal/domain/invitation/repository.go
+++ b/backends/go-gin/internal/domain/invitation/repository.go
@@ -2,10 +2,10 @@ package invitation
 
 // Repository は招待の永続化インターフェースです。
 type Repository interface {
-	// GetCurrent は最新の招待情報の値オブジェクトを返します。
-	GetCurrent() (*Vo, error)
+	// GetCurrentByRole はロールで絞り込んだ最新の招待情報の値オブジェクトを返します。
+	GetCurrentByRole(role int) (*Vo, error)
 	// Issue は新しい招待トークンを生成して保存し、値オブジェクトを返します。
-	Issue() (*Vo, error)
+	Issue(role int) (*Vo, error)
 	// FindByToken はトークンで招待情報の値オブジェクトを返します。
 	FindByToken(token string) (*Vo, error)
 }

--- a/backends/go-gin/internal/domain/invitation/value_objects.go
+++ b/backends/go-gin/internal/domain/invitation/value_objects.go
@@ -5,4 +5,5 @@ type Vo struct {
 	Token      string
 	URL        string
 	DisplayURL string
+	Role       int
 }

--- a/backends/go-gin/internal/handler/admin_invitation_handler.go
+++ b/backends/go-gin/internal/handler/admin_invitation_handler.go
@@ -3,7 +3,9 @@ package handler
 import (
 	dominvitation "authorization-go/internal/domain/invitation"
 	uinvitation "authorization-go/internal/usecase/invitation"
+	"authorization-go/pkg/apperror"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -24,9 +26,13 @@ func NewAdminInvitationHandler(db *gorm.DB, newInviteUC func(*gorm.DB) *uinvitat
 }
 
 // Index は現在の招待情報を返します。
-// GET /api/admin/invitation
+// GET /api/admin/invitation?role=2
 func (h *AdminInvitationHandler) Index(c *gin.Context) {
-	result, err := h.newInviteUC(h.db).Current()
+	role, ok := parseRoleParam(c)
+	if !ok {
+		return
+	}
+	result, err := h.newInviteUC(h.db).Current(uinvitation.CurrentDto{Role: role})
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -35,18 +41,36 @@ func (h *AdminInvitationHandler) Index(c *gin.Context) {
 }
 
 // Issue は新しい招待を発行して返します。
-// GET /api/admin/invitation/issue
+// GET /api/admin/invitation/issue?role=2
 func (h *AdminInvitationHandler) Issue(c *gin.Context) {
+	role, ok := parseRoleParam(c)
+	if !ok {
+		return
+	}
 	var result *dominvitation.Vo
 	if txErr := h.db.Transaction(func(tx *gorm.DB) error {
 		var e error
-		result, e = h.newInviteUC(tx).Issue()
+		result, e = h.newInviteUC(tx).Issue(uinvitation.IssueDto{Role: role})
 		return e
 	}); txErr != nil {
 		_ = c.Error(txErr)
 		return
 	}
 	c.JSON(http.StatusOK, mapInvitationVo(result))
+}
+
+// ---------- プライベートヘルパー ----------
+
+// parseRoleParam は role クエリパラメータを検証して返します。
+// 省略時はデフォルト 2、1 か 2 以外は 400 を返します。
+func parseRoleParam(c *gin.Context) (int, bool) {
+	roleStr := c.DefaultQuery("role", "2")
+	role, err := strconv.Atoi(roleStr)
+	if err != nil || (role != 1 && role != 2) {
+		_ = c.Error(apperror.BadRequest("invalid_role"))
+		return 0, false
+	}
+	return role, true
 }
 
 // ---------- 変換ヘルパー ----------

--- a/backends/go-gin/internal/infrastructure/cache/redis_invitation_auth_repository.go
+++ b/backends/go-gin/internal/infrastructure/cache/redis_invitation_auth_repository.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"authorization-go/internal/config"
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -19,20 +20,27 @@ func NewRedisInvitationAuthRepository(rdb *redis.Client, cfg *config.Config) *Re
 	return &RedisInvitationAuthRepository{rdb: rdb, cfg: cfg}
 }
 
-// Store はトークンを指定秒数 Redis にキャッシュします。
-func (r *RedisInvitationAuthRepository) Store(token string, ttl int) error {
+// Store はトークンとロールを指定秒数 Redis にキャッシュします。
+func (r *RedisInvitationAuthRepository) Store(token string, role int, ttl int) error {
 	ctx := context.Background()
-	return r.rdb.Set(ctx, r.key(token), token, time.Duration(ttl)*time.Second).Err()
+	return r.rdb.Set(ctx, r.key(token), strconv.Itoa(role), time.Duration(ttl)*time.Second).Err()
 }
 
-// Find はキャッシュからトークンを取得します。存在しない場合は空文字を返します。
-func (r *RedisInvitationAuthRepository) Find(token string) (string, error) {
+// Find はキャッシュからロールを取得します。存在しない場合は nil を返します。
+func (r *RedisInvitationAuthRepository) Find(token string) (*int, error) {
 	ctx := context.Background()
 	val, err := r.rdb.Get(ctx, r.key(token)).Result()
 	if err == redis.Nil {
-		return "", nil
+		return nil, nil
 	}
-	return val, err
+	if err != nil {
+		return nil, err
+	}
+	role, err := strconv.Atoi(val)
+	if err != nil {
+		return nil, err
+	}
+	return &role, nil
 }
 
 // Remove はキャッシュからトークンを削除します。

--- a/backends/go-gin/internal/infrastructure/model/model.go
+++ b/backends/go-gin/internal/infrastructure/model/model.go
@@ -61,6 +61,7 @@ func (Staff) TableName() string { return "staffs" }
 type Invitation struct {
 	ID        uint           `gorm:"primaryKey;autoIncrement;column:id"`
 	Token     string         `gorm:"not null;uniqueIndex;column:token"`
+	Role      int            `gorm:"not null;default:2;column:role"`
 	CreatedAt time.Time      `gorm:"column:created_at"`
 	CreatedBy *uint          `gorm:"column:created_by"`
 	UpdatedAt time.Time      `gorm:"column:updated_at"`

--- a/backends/go-gin/internal/infrastructure/persistence/gorm_invitation_repository.go
+++ b/backends/go-gin/internal/infrastructure/persistence/gorm_invitation_repository.go
@@ -27,20 +27,20 @@ func NewGormInvitationRepository(db *gorm.DB, frontendURL string) *GormInvitatio
 	return &GormInvitationRepository{db: db, frontendURL: frontendURL}
 }
 
-// GetCurrent は最新の招待情報の値オブジェクトを返します。
-func (r *GormInvitationRepository) GetCurrent() (*dominvitation.Vo, error) {
+// GetCurrentByRole はロールで絞り込んだ最新の招待情報の値オブジェクトを返します。
+func (r *GormInvitationRepository) GetCurrentByRole(role int) (*dominvitation.Vo, error) {
 	var m model.Invitation
-	if err := r.db.Order("id DESC").First(&m).Error; err != nil {
+	if err := r.db.Where("role = ?", role).Order("id DESC").First(&m).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	return r.buildVo(m.Token), nil
+	return r.buildVo(m.Token, m.Role), nil
 }
 
 // Issue は新しい招待トークンを生成して保存し、値オブジェクトを返します。
-func (r *GormInvitationRepository) Issue() (*dominvitation.Vo, error) {
+func (r *GormInvitationRepository) Issue(role int) (*dominvitation.Vo, error) {
 	token, err := generateInvitationToken()
 	if err != nil {
 		return nil, err
@@ -49,6 +49,7 @@ func (r *GormInvitationRepository) Issue() (*dominvitation.Vo, error) {
 	zero := uint(0)
 	m := model.Invitation{
 		Token:     token,
+		Role:      role,
 		CreatedAt: now,
 		CreatedBy: &zero,
 		UpdatedAt: now,
@@ -57,7 +58,7 @@ func (r *GormInvitationRepository) Issue() (*dominvitation.Vo, error) {
 	if err = r.db.Create(&m).Error; err != nil {
 		return nil, err
 	}
-	return r.buildVo(token), nil
+	return r.buildVo(token, role), nil
 }
 
 // FindByToken はトークンで招待情報の値オブジェクトを返します。
@@ -69,12 +70,12 @@ func (r *GormInvitationRepository) FindByToken(token string) (*dominvitation.Vo,
 		}
 		return nil, err
 	}
-	return r.buildVo(m.Token), nil
+	return r.buildVo(m.Token, m.Role), nil
 }
 
-func (r *GormInvitationRepository) buildVo(token string) *dominvitation.Vo {
+func (r *GormInvitationRepository) buildVo(token string, role int) *dominvitation.Vo {
 	url := fmt.Sprintf("%s/invitation/%s", r.frontendURL, token)
-	return &dominvitation.Vo{Token: token, URL: url, DisplayURL: buildDisplayURL(url)}
+	return &dominvitation.Vo{Token: token, URL: url, DisplayURL: buildDisplayURL(url), Role: role}
 }
 
 // buildDisplayURL は PHP の buildDisplayUrl と同じロジックで表示用 URL を生成します。

--- a/backends/go-gin/internal/usecase/auth/interactor.go
+++ b/backends/go-gin/internal/usecase/auth/interactor.go
@@ -53,11 +53,11 @@ func (uc *Interactor) Login(dto LoginDto) (*domstaff.Vo, error) {
 		if dto.InvitationToken == "" {
 			return nil, apperror.Forbidden("invitation_required")
 		}
-		found, err := uc.invitationAuthRepo.Find(dto.InvitationToken)
+		rolePtr, err := uc.invitationAuthRepo.Find(dto.InvitationToken)
 		if err != nil {
 			return nil, err
 		}
-		if found == "" {
+		if rolePtr == nil {
 			return nil, apperror.Forbidden("invitation_required")
 		}
 		if err := uc.invitationAuthRepo.Remove(dto.InvitationToken); err != nil {
@@ -71,7 +71,7 @@ func (uc *Interactor) Login(dto LoginDto) (*domstaff.Vo, error) {
 			Provider:    dto.Provider,
 			ProviderID:  dto.ProviderID,
 			Avatar:      dto.Avatar,
-			Role:        domstaff.RoleMember,
+			Role:        *rolePtr,
 			LastLoginAt: &now,
 			CreatedAt:   now,
 			CreatedBy:   &zero,

--- a/backends/go-gin/internal/usecase/auth/interactor.go
+++ b/backends/go-gin/internal/usecase/auth/interactor.go
@@ -60,6 +60,9 @@ func (uc *Interactor) Login(dto LoginDto) (*domstaff.Vo, error) {
 		if rolePtr == nil {
 			return nil, apperror.Forbidden("invitation_required")
 		}
+		if *rolePtr != domstaff.RoleAdmin && *rolePtr != domstaff.RoleMember {
+			return nil, apperror.Forbidden("invitation_required")
+		}
 		if err := uc.invitationAuthRepo.Remove(dto.InvitationToken); err != nil {
 			return nil, err
 		}

--- a/backends/go-gin/internal/usecase/invitation/dto.go
+++ b/backends/go-gin/internal/usecase/invitation/dto.go
@@ -1,5 +1,15 @@
 package invitation
 
+// CurrentDto は現在の招待情報取得のユースケース入力です。
+type CurrentDto struct {
+	Role int
+}
+
+// IssueDto は招待発行のユースケース入力です。
+type IssueDto struct {
+	Role int
+}
+
 // FindByTokenDto は招待トークン検索のユースケース入力です。
 type FindByTokenDto struct {
 	Token string

--- a/backends/go-gin/internal/usecase/invitation/interactor.go
+++ b/backends/go-gin/internal/usecase/invitation/interactor.go
@@ -20,11 +20,12 @@ func NewInteractor(repo dominvitation.Repository, authRepo dominvitation.AuthRep
 	return &Interactor{repo: repo, authRepo: authRepo}
 }
 
-// Current は最新の招待情報の値オブジェクトを返します。
+// Current は指定ロールの最新の招待情報の値オブジェクトを返します。
 //
+// dto: ロール指定 Dto
 // 戻り値: 招待 Vo、またはエラー
-func (uc *Interactor) Current() (*dominvitation.Vo, error) {
-	result, err := uc.repo.GetCurrent()
+func (uc *Interactor) Current(dto CurrentDto) (*dominvitation.Vo, error) {
+	result, err := uc.repo.GetCurrentByRole(dto.Role)
 	if err != nil {
 		return nil, err
 	}
@@ -36,12 +37,13 @@ func (uc *Interactor) Current() (*dominvitation.Vo, error) {
 
 // Issue は新しい招待トークンを発行し、招待情報の値オブジェクトを返します。
 //
+// dto: ロール指定 Dto
 // 戻り値: 招待 Vo、またはエラー
-func (uc *Interactor) Issue() (*dominvitation.Vo, error) {
-	return uc.repo.Issue()
+func (uc *Interactor) Issue(dto IssueDto) (*dominvitation.Vo, error) {
+	return uc.repo.Issue(dto.Role)
 }
 
-// FindByToken はトークンで招待情報を返し、招待認証トークンをキャッシュします。
+// FindByToken はトークンで招待情報を返し、招待認証ロールをキャッシュします。
 //
 // dto: トークン検索 Dto
 // 戻り値: 招待 Vo、またはエラー
@@ -56,7 +58,7 @@ func (uc *Interactor) FindByToken(dto FindByTokenDto) (*dominvitation.Vo, error)
 	if result == nil {
 		return nil, apperror.BadRequest("invitation_invalid")
 	}
-	if err := uc.authRepo.Store(result.Token, 600); err != nil {
+	if err := uc.authRepo.Store(result.Token, result.Role, 600); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/backends/go-gin/tests/schema.sql
+++ b/backends/go-gin/tests/schema.sql
@@ -63,6 +63,7 @@ CREATE TABLE `clients` (
 CREATE TABLE `invitations` (
     `id`            INT UNSIGNED    NOT NULL AUTO_INCREMENT,
     `token`         VARCHAR(255)    NOT NULL,
+    `role`          INT UNSIGNED    NOT NULL DEFAULT 2,
     `created_at`    TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `created_by`    INT UNSIGNED,
     `updated_at`    TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/invitation/AuthRepository.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/invitation/AuthRepository.kt
@@ -11,10 +11,10 @@ package com.authorization.domain.invitation
  * @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
  */
 interface AuthRepository {
-    /** トークンを指定秒数キャッシュします。 */
-    suspend fun store(token: String, ttl: Long)
-    /** トークンを取得します。存在しない場合は null を返します。 */
-    suspend fun find(token: String): String?
+    /** トークンとロールを指定秒数キャッシュします。 */
+    suspend fun store(token: String, role: Int, ttl: Long)
+    /** トークンに紐づくロールを取得します。存在しない場合は null を返します。 */
+    suspend fun find(token: String): Int?
     /** トークンを削除します。 */
     suspend fun remove(token: String)
 }

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/invitation/Entity.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/invitation/Entity.kt
@@ -15,6 +15,7 @@ import java.time.LocalDateTime
 data class Invitation(
     val id:        Int            = 0,
     val token:     String,
+    val role:      Int            = 2,
     val createdAt: LocalDateTime  = LocalDateTime.now(),
     val createdBy: Long?          = null,
     val updatedAt: LocalDateTime  = LocalDateTime.now(),

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/invitation/Repository.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/invitation/Repository.kt
@@ -13,18 +13,20 @@ package com.authorization.domain.invitation
 interface Repository {
 
     /**
-     * 現在有効な招待情報を取得します。
+     * 指定ロールの現在有効な招待情報を取得します。
      *
+     * @param role ロール（1=管理者、2=メンバー）
      * @return 招待 VO、または null
      */
-    suspend fun getCurrent(): Vo?
+    suspend fun getCurrentByRole(role: Int): Vo?
 
     /**
-     * 招待トークンを新規発行します。
+     * 指定ロールで招待トークンを新規発行します。
      *
+     * @param role ロール（1=管理者、2=メンバー）
      * @return 発行された招待 VO
      */
-    suspend fun issue(): Vo
+    suspend fun issue(role: Int): Vo
 
     /**
      * 招待トークンに一致する招待情報を取得します。

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/invitation/ValueObjects.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/invitation/ValueObjects.kt
@@ -12,6 +12,7 @@ package com.authorization.domain.invitation
  */
 data class Vo(
     val token:      String,
+    val role:       Int,
     val url:        String,
     val displayUrl: String,
 )

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/staff/Enums.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/staff/Enums.kt
@@ -15,6 +15,15 @@ object StaffRole {
     const val ADMIN:  Int = 1
     /** 一般メンバー */
     const val MEMBER: Int = 2
+
+    /**
+     * 整数値からロール定数を返します。
+     * 未知の値の場合は MEMBER を返します。
+     *
+     * @param value ロール整数値
+     * @return ADMIN または MEMBER
+     */
+    fun from(value: Int): Int = if (value == ADMIN) ADMIN else MEMBER
 }
 
 /**

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/handler/AdminInvitationHandler.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/handler/AdminInvitationHandler.kt
@@ -65,8 +65,9 @@ class AdminInvitationHandler(private val invitationUC: InvitationUC) {
      * 1 または 2 以外の場合は 400 を返し null を返します。
      */
     private suspend fun resolveRole(call: ApplicationCall): Int? {
-        val rawRole = call.request.queryParameters["role"]?.toIntOrNull() ?: 2
-        if (rawRole != 1 && rawRole != 2) {
+        val raw = call.request.queryParameters["role"] ?: return 2
+        val rawRole = raw.toIntOrNull()
+        if (rawRole == null || (rawRole != 1 && rawRole != 2)) {
             call.respond(HttpStatusCode.BadRequest, buildJsonObject { put("error", "invalid_role") })
             return null
         }

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/handler/AdminInvitationHandler.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/handler/AdminInvitationHandler.kt
@@ -6,6 +6,7 @@
 package com.authorization.handler
 
 import com.authorization.usecase.invitation.Interactor as InvitationUC
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import kotlinx.serialization.json.*
@@ -20,11 +21,13 @@ class AdminInvitationHandler(private val invitationUC: InvitationUC) {
 
     /**
      * 現在有効な招待トークンを取得します。
+     * クエリパラメータ role（1=管理者、2=メンバー、デフォルト 2）でフィルタします。
      *
      * @param call アプリケーションコール
      */
     suspend fun index(call: ApplicationCall) {
-        val v = invitationUC.current()
+        val role = resolveRole(call) ?: return
+        val v = invitationUC.current(role)
         call.respond(buildJsonObject {
             put("found",       true)
             put("url",         v.url)
@@ -35,16 +38,38 @@ class AdminInvitationHandler(private val invitationUC: InvitationUC) {
 
     /**
      * 招待トークンを新規発行します。
+     * クエリパラメータ role（1=管理者、2=メンバー、デフォルト 2）でロールを指定します。
+     * 認証クッキーがない場合は 401 を返します。
      *
      * @param call アプリケーションコール
      */
     suspend fun issue(call: ApplicationCall) {
-        val v = newSuspendedTransaction { invitationUC.issue() }
+        val staffId = call.request.cookies["staff_id"]?.toLongOrNull() ?: 0L
+        if (staffId == 0L) {
+            call.respond(HttpStatusCode.Unauthorized, buildJsonObject { put("error", "unauthenticated") })
+            return
+        }
+        val role = resolveRole(call) ?: return
+        val v = newSuspendedTransaction { invitationUC.issue(role) }
         call.respond(buildJsonObject {
             put("found",       true)
             put("url",         v.url)
             put("display_url", v.displayUrl)
             put("token",       v.token)
         })
+    }
+
+    /**
+     * クエリパラメータ role を解決します。
+     * 未指定の場合は 2（メンバー）を返します。
+     * 1 または 2 以外の場合は 400 を返し null を返します。
+     */
+    private suspend fun resolveRole(call: ApplicationCall): Int? {
+        val rawRole = call.request.queryParameters["role"]?.toIntOrNull() ?: 2
+        if (rawRole != 1 && rawRole != 2) {
+            call.respond(HttpStatusCode.BadRequest, buildJsonObject { put("error", "invalid_role") })
+            return null
+        }
+        return rawRole
     }
 }

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/cache/RedisInvitationAuthRepository.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/cache/RedisInvitationAuthRepository.kt
@@ -19,12 +19,12 @@ class RedisInvitationAuthRepository(
     private val cfg: Config,
 ) : AuthRepository {
 
-    override suspend fun store(token: String, ttl: Long) {
-        pool.resource.use { it.setex(cacheKey(token), ttl, token) }
+    override suspend fun store(token: String, role: Int, ttl: Long) {
+        pool.resource.use { it.setex(cacheKey(token), ttl, role.toString()) }
     }
 
-    override suspend fun find(token: String): String? =
-        pool.resource.use { it.get(cacheKey(token)) }
+    override suspend fun find(token: String): Int? =
+        pool.resource.use { it.get(cacheKey(token))?.toIntOrNull() }
 
     override suspend fun remove(token: String) {
         pool.resource.use { it.del(cacheKey(token)) }

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/model/Tables.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/model/Tables.kt
@@ -57,6 +57,7 @@ object Staffs : LongIdTable("staffs") {
 /** 招待テーブル定義です。 */
 object Invitations : IntIdTable("invitations") {
     val token     = varchar("token", 255).uniqueIndex()
+    val role      = integer("role").default(2)
     val createdAt = datetime("created_at")
     val createdBy = integer("created_by").nullable()
     val updatedAt = datetime("updated_at")

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/persistence/ExposedInvitationRepository.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/persistence/ExposedInvitationRepository.kt
@@ -26,35 +26,38 @@ import java.time.LocalDateTime
 class ExposedInvitationRepository(private val db: Database, private val cfg: Config) : Repository {
 
     /**
-     * 現在有効な招待情報を取得します。
+     * 指定ロールの現在有効な招待情報を取得します。
      *
+     * @param role ロール（1=管理者、2=メンバー）
      * @return 招待 VO、または null
      */
-    override suspend fun getCurrent(): Vo? = newSuspendedTransaction(db = db) {
+    override suspend fun getCurrentByRole(role: Int): Vo? = newSuspendedTransaction(db = db) {
         Invitations.selectAll()
-            .where { Invitations.deletedAt.isNull() }
+            .where { (Invitations.role eq role) and Invitations.deletedAt.isNull() }
             .orderBy(Invitations.createdAt to SortOrder.DESC)
             .limit(1)
             .firstOrNull()
-            ?.let { buildVo(it[Invitations.token]) }
+            ?.let { buildVo(it[Invitations.token], it[Invitations.role]) }
     }
 
     /**
-     * 招待トークンを新規発行します。
+     * 指定ロールで招待トークンを新規発行します。
      *
+     * @param role ロール（1=管理者、2=メンバー）
      * @return 発行された招待 VO
      */
-    override suspend fun issue(): Vo = newSuspendedTransaction(db = db) {
+    override suspend fun issue(role: Int): Vo = newSuspendedTransaction(db = db) {
         val now   = LocalDateTime.now()
         val token = generateHex(16)
         Invitations.insert {
             it[Invitations.token]     = token
+            it[Invitations.role]      = role
             it[Invitations.createdAt] = now
             it[Invitations.createdBy] = 0
             it[Invitations.updatedAt] = now
             it[Invitations.updatedBy] = 0
         }
-        buildVo(token)
+        buildVo(token, role)
     }
 
     /**
@@ -67,7 +70,7 @@ class ExposedInvitationRepository(private val db: Database, private val cfg: Con
         Invitations.selectAll()
             .where { (Invitations.token eq token) and Invitations.deletedAt.isNull() }
             .firstOrNull()
-            ?.let { buildVo(it[Invitations.token]) }
+            ?.let { buildVo(it[Invitations.token], it[Invitations.role]) }
     }
 
     private fun generateHex(byteCount: Int): String {
@@ -76,10 +79,10 @@ class ExposedInvitationRepository(private val db: Database, private val cfg: Con
         return buf.joinToString("") { "%02x".format(it) }
     }
 
-    private fun buildVo(token: String): Vo {
+    private fun buildVo(token: String, role: Int): Vo {
         val url        = "${cfg.app.frontendUrl}/invitation/$token"
         val displayUrl = buildDisplayUrl(url)
-        return Vo(token = token, url = url, displayUrl = displayUrl)
+        return Vo(token = token, role = role, url = url, displayUrl = displayUrl)
     }
 
     private fun buildDisplayUrl(url: String): String {

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/usecase/auth/Interactor.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/usecase/auth/Interactor.kt
@@ -49,17 +49,18 @@ class Interactor(
             )
         } else {
             val token = dto.invitationToken
-            if (token.isNullOrEmpty() || invitationAuthRepo.find(token) == null) {
+            val roleValue = if (!token.isNullOrEmpty()) invitationAuthRepo.find(token) else null
+            if (roleValue == null) {
                 throw AppException(403, "invitation_required")
             }
-            invitationAuthRepo.remove(token)
+            invitationAuthRepo.remove(token!!)
             Staff(
                 name        = dto.name,
                 email       = dto.email,
                 provider    = dto.provider,
                 providerId  = dto.providerId,
                 avatar      = dto.avatar,
-                role        = StaffRole.MEMBER,
+                role        = StaffRole.from(roleValue),
                 lastLoginAt = now,
                 createdAt   = now,
                 updatedAt   = now,

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/usecase/invitation/Interactor.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/usecase/invitation/Interactor.kt
@@ -20,29 +20,31 @@ class Interactor(
 ) {
 
     /**
-     * 現在有効な招待情報を取得します。
+     * 指定ロールの現在有効な招待情報を取得します。
      *
+     * @param role ロール（1=管理者、2=メンバー）
      * @return 招待 VO
      */
-    suspend fun current(): Vo =
-        invitationRepo.getCurrent() ?: error("invitation_not_found")
+    suspend fun current(role: Int): Vo =
+        invitationRepo.getCurrentByRole(role) ?: error("invitation_not_found")
 
     /**
-     * 招待トークンを新規発行します。
+     * 指定ロールで招待トークンを新規発行します。
      *
+     * @param role ロール（1=管理者、2=メンバー）
      * @return 発行された招待 VO
      */
-    suspend fun issue(): Vo = invitationRepo.issue()
+    suspend fun issue(role: Int): Vo = invitationRepo.issue(role)
 
     /**
-     * 招待トークンに一致する招待情報を取得し、認証トークンをキャッシュします。
+     * 招待トークンに一致する招待情報を取得し、ロールをキャッシュします。
      *
      * @param dto 検索 DTO
      * @return 招待 VO
      */
     suspend fun findByToken(dto: FindByTokenDto): Vo {
         val vo = invitationRepo.findByToken(dto.token) ?: error("invitation_not_found")
-        invitationAuthRepo.store(vo.token, 600L)
+        invitationAuthRepo.store(vo.token, vo.role, 600L)
         return vo
     }
 }

--- a/backends/kotlin-ktor/src/test/kotlin/com/authorization/integration/AdminInvitationIntegrationTest.kt
+++ b/backends/kotlin-ktor/src/test/kotlin/com/authorization/integration/AdminInvitationIntegrationTest.kt
@@ -23,8 +23,8 @@ class AdminInvitationIntegrationTest {
     @Test
     fun `GET api admin invitation returns current invitation`() = testApplication {
         application { module(TestHelper.cfg) }
-        val inv = TestHelper.createInvitation()
-        val response = client.get("/api/admin/invitation")
+        val inv = TestHelper.createInvitation(role = 2)
+        val response = client.get("/api/admin/invitation?role=2")
         assertEquals(HttpStatusCode.OK, response.status)
         val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
         assertTrue(body["found"]!!.jsonPrimitive.boolean)
@@ -34,10 +34,27 @@ class AdminInvitationIntegrationTest {
     @Test
     fun `GET api admin invitation issue issues new invitation`() = testApplication {
         application { module(TestHelper.cfg) }
-        val response = client.get("/api/admin/invitation/issue")
+        val staff = TestHelper.createStaff()
+        val response = client.get("/api/admin/invitation/issue?role=2") {
+            header(HttpHeaders.Cookie, "staff_id=${staff.id}")
+        }
         assertEquals(HttpStatusCode.OK, response.status)
         val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
         assertTrue(body["found"]!!.jsonPrimitive.boolean)
         assertNotNull(body["token"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `GET api admin invitation issue returns 401 when unauthenticated`() = testApplication {
+        application { module(TestHelper.cfg) }
+        val response = client.get("/api/admin/invitation/issue?role=2")
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `GET api admin invitation returns 400 for invalid role`() = testApplication {
+        application { module(TestHelper.cfg) }
+        val response = client.get("/api/admin/invitation?role=3")
+        assertEquals(HttpStatusCode.BadRequest, response.status)
     }
 }

--- a/backends/kotlin-ktor/src/test/kotlin/com/authorization/integration/TestHelper.kt
+++ b/backends/kotlin-ktor/src/test/kotlin/com/authorization/integration/TestHelper.kt
@@ -97,11 +97,15 @@ object TestHelper {
         return ClientRow(id, identifier, token)
     }
 
-    fun createInvitation(token: String = UUID.randomUUID().toString().replace("-", "").take(32)): InvitationRow {
+    fun createInvitation(
+        token: String = UUID.randomUUID().toString().replace("-", "").take(32),
+        role: Int = 2,
+    ): InvitationRow {
         val now = LocalDateTime.now()
         val id = transaction(db) {
             Invitations.insertAndGetId {
                 it[Invitations.token]     = token
+                it[Invitations.role]      = role
                 it[Invitations.createdAt] = now
                 it[Invitations.updatedAt] = now
             }.value

--- a/backends/kotlin-ktor/src/test/kotlin/com/authorization/usecase/auth/InteractorTest.kt
+++ b/backends/kotlin-ktor/src/test/kotlin/com/authorization/usecase/auth/InteractorTest.kt
@@ -39,14 +39,14 @@ class InteractorTest {
         override suspend fun restore(id: Long)                                       = true
     }
 
-    private fun mockInvAuthRepo(storedToken: String? = null): InvAuthRepository = object : InvAuthRepository {
-        override suspend fun store(token: String, ttl: Long) {}
-        override suspend fun find(token: String) = storedToken
+    private fun mockInvAuthRepo(storedRole: Int? = null): InvAuthRepository = object : InvAuthRepository {
+        override suspend fun store(token: String, role: Int, ttl: Long) {}
+        override suspend fun find(token: String) = storedRole
         override suspend fun remove(token: String) {}
     }
 
-    private fun makeUc(staffRepo: Repository, storedToken: String? = null) =
-        Interactor(staffRepo, mockInvAuthRepo(storedToken))
+    private fun makeUc(staffRepo: Repository, storedRole: Int? = null) =
+        Interactor(staffRepo, mockInvAuthRepo(storedRole))
 
     @Test
     fun `findUser returns staff when found`() = runBlocking {
@@ -65,12 +65,21 @@ class InteractorTest {
     }
 
     @Test
-    fun `login creates new staff with valid invitation token`() = runBlocking {
-        val uc     = makeUc(mockRepo(findByProvider = null), storedToken = "tok")
+    fun `login creates new staff with valid invitation token and member role`() = runBlocking {
+        val uc     = makeUc(mockRepo(findByProvider = null), storedRole = StaffRole.MEMBER)
         val dto    = LoginDto(provider = 1, providerId = "new-id", name = "New User", email = "new@example.com", avatar = null, invitationToken = "tok")
         val result = uc.login(dto)
         assertEquals("New User", result.name)
         assertEquals(StaffRole.MEMBER, result.role)
+    }
+
+    @Test
+    fun `login creates new staff with valid invitation token and admin role`() = runBlocking {
+        val uc     = makeUc(mockRepo(findByProvider = null), storedRole = StaffRole.ADMIN)
+        val dto    = LoginDto(provider = 1, providerId = "new-id", name = "New User", email = "new@example.com", avatar = null, invitationToken = "tok")
+        val result = uc.login(dto)
+        assertEquals("New User", result.name)
+        assertEquals(StaffRole.ADMIN, result.role)
     }
 
     @Test

--- a/backends/kotlin-ktor/src/test/kotlin/com/authorization/usecase/invitation/InteractorTest.kt
+++ b/backends/kotlin-ktor/src/test/kotlin/com/authorization/usecase/invitation/InteractorTest.kt
@@ -9,46 +9,47 @@ import kotlin.test.assertEquals
 
 class InteractorTest {
 
-    private fun makeVo(token: String = "tok123") = Vo(
+    private fun makeVo(token: String = "tok123", role: Int = 2) = Vo(
         token      = token,
+        role       = role,
         url        = "http://localhost:3000/register?token=$token",
         displayUrl = "http://localhost...token=$token",
     )
 
     private fun mockRepo(
-        current: Vo? = null,
+        currentByRole: Vo? = null,
         issued: Vo = makeVo(),
         byToken: Vo? = null,
     ): Repository = object : Repository {
-        override suspend fun getCurrent()               = current
-        override suspend fun issue()                    = issued
-        override suspend fun findByToken(token: String) = byToken
+        override suspend fun getCurrentByRole(role: Int)    = currentByRole
+        override suspend fun issue(role: Int)               = issued
+        override suspend fun findByToken(token: String)     = byToken
     }
 
     private val stubAuthRepo: AuthRepository = object : AuthRepository {
-        override suspend fun store(token: String, ttl: Long) {}
-        override suspend fun find(token: String): String? = null
+        override suspend fun store(token: String, role: Int, ttl: Long) {}
+        override suspend fun find(token: String): Int? = null
         override suspend fun remove(token: String) {}
     }
 
     @Test
     fun `current returns vo when found`() = runBlocking {
-        val uc = Interactor(mockRepo(current = makeVo("abc")), stubAuthRepo)
-        assertEquals("abc", uc.current().token)
+        val uc = Interactor(mockRepo(currentByRole = makeVo("abc")), stubAuthRepo)
+        assertEquals("abc", uc.current(2).token)
     }
 
     @Test
     fun `current throws when not found`() = runBlocking {
-        val uc = Interactor(mockRepo(current = null), stubAuthRepo)
+        val uc = Interactor(mockRepo(currentByRole = null), stubAuthRepo)
         var threw = false
-        try { uc.current() } catch (_: Exception) { threw = true }
+        try { uc.current(2) } catch (_: Exception) { threw = true }
         assertEquals(true, threw)
     }
 
     @Test
     fun `issue returns new vo`() = runBlocking {
         val uc = Interactor(mockRepo(issued = makeVo("newtoken")), stubAuthRepo)
-        val vo = uc.issue()
+        val vo = uc.issue(2)
         assertEquals("newtoken", vo.token)
     }
 

--- a/backends/php-laravel/app/Domain/Invitation/Entities/Invitation.php
+++ b/backends/php-laravel/app/Domain/Invitation/Entities/Invitation.php
@@ -23,4 +23,6 @@ class Invitation extends AbstractEntity
     public ?int $id = null;
 
     public ?string $token = null;
+
+    public ?int $role = null;
 }

--- a/backends/php-laravel/app/Domain/Invitation/Repositories/InvitationAuthRepository.php
+++ b/backends/php-laravel/app/Domain/Invitation/Repositories/InvitationAuthRepository.php
@@ -19,20 +19,21 @@ namespace App\Domain\Invitation\Repositories;
 interface InvitationAuthRepository
 {
     /**
-     * 招待トークンを一時保存します。
+     * 招待トークンとロールを一時保存します。
      *
      * @param string $token 招待トークン
+     * @param int $role 権限（1=管理者, 2=メンバー）
      * @param int $ttl 有効期限（秒）
      */
-    public function store(string $token, int $ttl): void;
+    public function store(string $token, int $role, int $ttl): void;
 
     /**
-     * 招待トークンを取得します。
+     * 招待トークンに紐づくロールを取得します。
      *
      * @param string $token 招待トークン
-     * @return string|null トークン文字列、未保存の場合 null
+     * @return int|null ロール、未保存の場合 null
      */
-    public function find(string $token): ?string;
+    public function find(string $token): ?int;
 
     /**
      * 招待トークンを削除します。

--- a/backends/php-laravel/app/Domain/Invitation/Repositories/InvitationRepository.php
+++ b/backends/php-laravel/app/Domain/Invitation/Repositories/InvitationRepository.php
@@ -22,11 +22,12 @@ use App\Domain\Invitation\Entities\Invitation;
 interface InvitationRepository
 {
     /**
-     * 現在の招待情報を取得します。
+     * 指定ロールの招待情報を取得します。
      *
+     * @param int $role 権限（1=管理者, 2=メンバー）
      * @return Invitation|null 未設定時は null
      */
-    public function getCurrent(): ?Invitation;
+    public function getCurrentByRole(int $role): ?Invitation;
 
     /**
      * 招待を更新します。

--- a/backends/php-laravel/app/Http/Controllers/Api/Admin/InvitationController.php
+++ b/backends/php-laravel/app/Http/Controllers/Api/Admin/InvitationController.php
@@ -36,7 +36,9 @@ class InvitationController extends Controller
      */
     public function index(AppRequest $request, InvitationService $service): JsonResponse
     {
-        $vo = $service->current(new InvitationDto());
+        $dto = new InvitationDto();
+        $dto->role = $this->resolveRole($request);
+        $vo = $service->current($dto);
 
         $response = new InvitationIndexResponse();
         $response->assign($vo->attributes());
@@ -53,8 +55,14 @@ class InvitationController extends Controller
      */
     public function issue(AppRequest $request, InvitationService $service): JsonResponse
     {
+        $executorId = $this->staffIdFromCookie($request);
+        if ($executorId === null) {
+            throw \App\Support\Exceptions\AppException::unauthorized('unauthenticated');
+        }
+
         $dto = new InvitationDto();
-        $dto->executorId = $this->staffIdFromCookie($request);
+        $dto->role = $this->resolveRole($request);
+        $dto->executorId = $executorId;
         $vo = DB::transaction(function () use ($service, $dto) {
             return $service->issue($dto);
         });
@@ -63,5 +71,20 @@ class InvitationController extends Controller
         $response->assign($vo->attributes());
 
         return response()->success($response->attributes());
+    }
+
+    /**
+     * クエリパラメーターから role を取得します（1 or 2、それ以外は 400）。
+     *
+     * @param AppRequest $request HTTP リクエスト
+     * @return int 権限（1=管理者, 2=メンバー）
+     */
+    private function resolveRole(AppRequest $request): int
+    {
+        $role = (int)$request->query('role', 2);
+        if (!in_array($role, [1, 2], true)) {
+            throw \App\Support\Exceptions\AppException::badRequest('invalid_role');
+        }
+        return $role;
     }
 }

--- a/backends/php-laravel/app/Http/Controllers/Api/Admin/InvitationController.php
+++ b/backends/php-laravel/app/Http/Controllers/Api/Admin/InvitationController.php
@@ -81,7 +81,14 @@ class InvitationController extends Controller
      */
     private function resolveRole(AppRequest $request): int
     {
-        $role = (int)$request->query('role', 2);
+        $raw = $request->query('role');
+        if ($raw === null) {
+            return 2;
+        }
+        if (!ctype_digit((string)$raw)) {
+            throw \App\Support\Exceptions\AppException::badRequest('invalid_role');
+        }
+        $role = (int)$raw;
         if (!in_array($role, [1, 2], true)) {
             throw \App\Support\Exceptions\AppException::badRequest('invalid_role');
         }

--- a/backends/php-laravel/app/Infrastructure/Cache/RedisInvitationAuthRepository.php
+++ b/backends/php-laravel/app/Infrastructure/Cache/RedisInvitationAuthRepository.php
@@ -27,19 +27,19 @@ class RedisInvitationAuthRepository extends AbstractCacheRepository implements I
      * {@inheritdoc}
      */
     #[\Override]
-    public function store(string $token, int $ttl): void
+    public function store(string $token, int $role, int $ttl): void
     {
-        $this->put(self::TAG, self::TAG . ':' . $token, $token, $ttl);
+        $this->put(self::TAG, self::TAG . ':' . $token, (string)$role, $ttl);
     }
 
     /**
      * {@inheritdoc}
      */
     #[\Override]
-    public function find(string $token): ?string
+    public function find(string $token): ?int
     {
         $value = $this->get(self::TAG, self::TAG . ':' . $token);
-        return is_string($value) ? $value : null;
+        return is_numeric($value) ? (int)$value : null;
     }
 
     /**

--- a/backends/php-laravel/app/Infrastructure/Persistence/EloquentInvitationRepository.php
+++ b/backends/php-laravel/app/Infrastructure/Persistence/EloquentInvitationRepository.php
@@ -14,9 +14,7 @@ use App\Domain\Invitation\Condition\InvitationCondition;
 use App\Domain\Invitation\Entities\Invitation as Entity;
 use App\Domain\Invitation\Repositories\InvitationRepository;
 use App\Infrastructure\Models\Invitation as Model;
-use App\Support\Enums\SortType;
 use App\Support\Repositories\AbstractEloquentRepository;
-use App\Support\Repositories\Conditions\Option;
 
 /**
  * 招待Repositoryクラスです。
@@ -30,10 +28,9 @@ class EloquentInvitationRepository extends AbstractEloquentRepository implements
      * {@inheritdoc}
      */
     #[\Override]
-    public function getCurrent(): ?Entity
+    public function getCurrentByRole(int $role): ?Entity
     {
-        $option = new Option(null, null, 'id', SortType::DESC);
-        $list = $this->all($option);
+        $list = $this->findByMap(['role' => $role]);
 
         if ($list->isEmpty()) {
             return null;

--- a/backends/php-laravel/app/UseCases/Auth/AuthService.php
+++ b/backends/php-laravel/app/UseCases/Auth/AuthService.php
@@ -79,14 +79,15 @@ class AuthService extends AbstractService
         if (empty($entity)) {
             // 新規ユーザー: 招待トークンを検証
             $token = $dto->invitationToken;
-            if (empty($token) || $this->invitationAuthRepository->find($token) === null) {
+            $roleValue = empty($token) ? null : $this->invitationAuthRepository->find($token);
+            if ($roleValue === null) {
                 throw AppException::forbidden('invitation_required');
             }
             $this->invitationAuthRepository->remove($token);
 
             $newEntity = new Staff();
             $newEntity->assign($dto->attributes());
-            $newEntity->role = StaffRole::Member;
+            $newEntity->role = StaffRole::from($roleValue);
             $newEntity->lastLoginAt = Carbon::now();
             $newEntity->assignCreated(0);
             $saved = $this->staffRepository->persist($newEntity);

--- a/backends/php-laravel/app/UseCases/Invitation/Dtos/InvitationDto.php
+++ b/backends/php-laravel/app/UseCases/Invitation/Dtos/InvitationDto.php
@@ -21,4 +21,6 @@ use App\Support\Dtos\AbstractDto;
 class InvitationDto extends AbstractDto
 {
     public ?string $token = null;
+
+    public ?int $role = null;
 }

--- a/backends/php-laravel/app/UseCases/Invitation/InvitationService.php
+++ b/backends/php-laravel/app/UseCases/Invitation/InvitationService.php
@@ -72,6 +72,9 @@ class InvitationService extends AbstractService
     public function issue(InvitationDto $dto): InvitationVo
     {
         $entity = $this->invitationRepository->getCurrentByRole($dto->role ?? 2);
+        if ($entity === null) {
+            throw AppException::notFound('invitation_not_found');
+        }
         $entity->token = bin2hex(random_bytes(16));
         $entity->assignUpdated($dto->executorId);
         $saved = $this->invitationRepository->persist($entity);

--- a/backends/php-laravel/app/UseCases/Invitation/InvitationService.php
+++ b/backends/php-laravel/app/UseCases/Invitation/InvitationService.php
@@ -48,8 +48,7 @@ class InvitationService extends AbstractService
      */
     public function current(InvitationDto $dto): InvitationVo
     {
-        unset($dto);
-        $entity = $this->invitationRepository->getCurrent();
+        $entity = $this->invitationRepository->getCurrentByRole($dto->role ?? 2);
         if ($entity === null) {
             throw AppException::notFound('invitation_not_found');
         }
@@ -72,7 +71,7 @@ class InvitationService extends AbstractService
      */
     public function issue(InvitationDto $dto): InvitationVo
     {
-        $entity = $this->invitationRepository->getCurrent();
+        $entity = $this->invitationRepository->getCurrentByRole($dto->role ?? 2);
         $entity->token = bin2hex(random_bytes(16));
         $entity->assignUpdated($dto->executorId);
         $saved = $this->invitationRepository->persist($entity);
@@ -105,8 +104,8 @@ class InvitationService extends AbstractService
             throw AppException::badRequest('invitation_invalid');
         }
 
-        // 招待トークンを一時保存（10分間）
-        $this->invitationAuthRepository->store($entity->token, 600);
+        // 招待トークンとロールを一時保存（10分間）
+        $this->invitationAuthRepository->store($entity->token, $entity->role ?? 2, 600);
 
         $url = $this->buildUrl($entity->token);
         return new InvitationVo()->assign([

--- a/backends/php-laravel/database/data/local/1-invitations.csv
+++ b/backends/php-laravel/database/data/local/1-invitations.csv
@@ -1,2 +1,3 @@
-id,token,created_by,updated_by
-1,b9195889-36c7-631e-76ab-867fa6ad42dc,0,0
+id,token,role,created_by,updated_by
+1,8f13761980983d1d9e3950d11b42016f,1,0,0
+2,57ccff5512b483cfbfe0d1a365b34069,2,0,0

--- a/backends/php-laravel/database/factories/InvitationFactory.php
+++ b/backends/php-laravel/database/factories/InvitationFactory.php
@@ -34,6 +34,7 @@ class InvitationFactory extends Factory
     {
         return [
             'token' => bin2hex(random_bytes(16)),
+            'role' => 2,
             'created_at' => now(),
             'created_by' => 1,
             'updated_at' => now(),

--- a/backends/php-laravel/database/migrations/2026_05_16_000000_add_role_to_invitations_table.php
+++ b/backends/php-laravel/database/migrations/2026_05_16_000000_add_role_to_invitations_table.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This is a program developed by BobTabo.
+ *
+ * Copyright (c) 2026 BobTabo. All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 招待テーブルにロールカラムを追加するMigrationクラスです。
+ *
+ * @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
+ */
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('invitations', function (Blueprint $table) {
+            $table->integer('role')->unsigned()->default(2)->comment('権限')->after('token');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('invitations', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/backends/php-laravel/tests/Feature/Admin/InvitationControllerTest.php
+++ b/backends/php-laravel/tests/Feature/Admin/InvitationControllerTest.php
@@ -32,8 +32,8 @@ class InvitationControllerTest extends TestCase
      */
     public function testIndex(): void
     {
-        Invitation::factory()->create(['token' => 'test-current-token']);
-        $response = $this->get('/api/admin/invitation');
+        Invitation::factory()->create(['token' => 'test-current-token', 'role' => 2]);
+        $response = $this->get('/api/admin/invitation?role=2');
         $data = $this->getResponseData('Invitation/index.json');
         $response
             ->assertStatus(200)
@@ -47,11 +47,11 @@ class InvitationControllerTest extends TestCase
      */
     public function testIssue(): void
     {
-        Invitation::factory()->create();
+        Invitation::factory()->create(['role' => 2]);
         $staff = Staff::factory()->create();
 
         $response = $this->withStaffCookie($staff->id)
-            ->get('/api/admin/invitation/issue');
+            ->get('/api/admin/invitation/issue?role=2');
         $response
             ->assertStatus(200)
             ->assertJsonStructure(['url', 'token']);

--- a/backends/php-laravel/tests/Feature/AuthControllerTest.php
+++ b/backends/php-laravel/tests/Feature/AuthControllerTest.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Domain\Invitation\Repositories\InvitationAuthRepository;
 use App\Infrastructure\Models\Invitation;
 use App\Infrastructure\Models\Staff;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Support\Facades\Cache;
 use Laravel\Socialite\Facades\Socialite;
 use Mockery;
 use Tests\TestCase;
@@ -112,7 +112,7 @@ class AuthControllerTest extends TestCase
     public function testGoogleCallbackNewUserWithInvitation(): void
     {
         $token = 'valid-invitation-token';
-        Cache::put('invitation_auth.invitation_auth:' . $token, $token, 600);
+        $this->app->make(InvitationAuthRepository::class)->store($token, 2, 600);
 
         $abstractUser = Mockery::mock('Laravel\Socialite\Two\User');
         $abstractUser->shouldReceive('getId')->andReturn('new-user-999');
@@ -130,7 +130,7 @@ class AuthControllerTest extends TestCase
 
         $frontendUrl = config('authorization.app.frontend_url');
         $response->assertRedirect($frontendUrl . '/clients');
-        $this->assertNull(Cache::get('invitation_auth.invitation_auth:' . $token));
+        $this->assertNull($this->app->make(InvitationAuthRepository::class)->find($token));
     }
 
     /**

--- a/backends/python-fastapi/app/domain/invitation/auth_repository.py
+++ b/backends/python-fastapi/app/domain/invitation/auth_repository.py
@@ -11,12 +11,12 @@ class InvitationAuthRepository(ABC):
     """招待認証トークンのキャッシュリポジトリインターフェース。"""
 
     @abstractmethod
-    def store(self, token: str, ttl: int) -> None:
-        """トークンを指定秒数キャッシュします。"""
+    def store(self, token: str, role: int, ttl: int) -> None:
+        """トークンとロールを指定秒数キャッシュします。"""
 
     @abstractmethod
-    def find(self, token: str) -> Optional[str]:
-        """トークンを取得します。存在しない場合は None を返します。"""
+    def find(self, token: str) -> Optional[int]:
+        """トークンに対応するロールを取得します。存在しない場合は None を返します。"""
 
     @abstractmethod
     def remove(self, token: str) -> None:

--- a/backends/python-fastapi/app/domain/invitation/entity.py
+++ b/backends/python-fastapi/app/domain/invitation/entity.py
@@ -13,5 +13,6 @@ class Invitation:
     """招待のドメインエンティティ（SQLAlchemy タグなし）。"""
     id: int = 0
     token: str = ""
+    role: int = 2
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None

--- a/backends/python-fastapi/app/domain/invitation/repository.py
+++ b/backends/python-fastapi/app/domain/invitation/repository.py
@@ -13,8 +13,11 @@ class InvitationRepository(ABC):
     """招待の永続化インターフェース。"""
 
     @abstractmethod
-    def get_current(self) -> Optional[InvitationVo]:
-        """最新の招待情報の Vo を返します。
+    def get_current_by_role(self, role: int) -> Optional[InvitationVo]:
+        """ロールで絞り込んだ最新の招待情報の Vo を返します。
+
+        Args:
+            role: ロール（1=管理者, 2=メンバー）
 
         Returns:
             InvitationVo、または None
@@ -22,8 +25,11 @@ class InvitationRepository(ABC):
         ...
 
     @abstractmethod
-    def issue(self) -> InvitationVo:
+    def issue(self, role: int) -> InvitationVo:
         """新しい招待トークンを生成して保存し、Vo を返します。
+
+        Args:
+            role: ロール（1=管理者, 2=メンバー）
 
         Returns:
             InvitationVo インスタンス

--- a/backends/python-fastapi/app/domain/invitation/value_objects.py
+++ b/backends/python-fastapi/app/domain/invitation/value_objects.py
@@ -12,3 +12,4 @@ class InvitationVo:
     token: str
     url: str
     display_url: str
+    role: int = 2

--- a/backends/python-fastapi/app/infrastructure/cache/redis_invitation_auth_repository.py
+++ b/backends/python-fastapi/app/infrastructure/cache/redis_invitation_auth_repository.py
@@ -20,12 +20,15 @@ class RedisInvitationAuthRepository(InvitationAuthRepository):
         prefix = self.settings.cache_prefix
         return f"{prefix}:invitation_auth:invitation_auth:{token}"
 
-    def store(self, token: str, ttl: int) -> None:
-        self.rdb.setex(self._key(token), ttl, token)
+    def store(self, token: str, role: int, ttl: int) -> None:
+        self.rdb.setex(self._key(token), ttl, str(role))
 
-    def find(self, token: str) -> Optional[str]:
+    def find(self, token: str) -> Optional[int]:
         val = self.rdb.get(self._key(token))
-        return val.decode() if isinstance(val, bytes) else val
+        if val is None:
+            return None
+        raw = val.decode() if isinstance(val, bytes) else val
+        return int(raw)
 
     def remove(self, token: str) -> None:
         self.rdb.delete(self._key(token))

--- a/backends/python-fastapi/app/infrastructure/cache/redis_invitation_auth_repository.py
+++ b/backends/python-fastapi/app/infrastructure/cache/redis_invitation_auth_repository.py
@@ -28,7 +28,13 @@ class RedisInvitationAuthRepository(InvitationAuthRepository):
         if val is None:
             return None
         raw = val.decode() if isinstance(val, bytes) else val
-        return int(raw)
+        try:
+            role = int(raw)
+        except (ValueError, TypeError):
+            return None
+        if role not in (1, 2):
+            return None
+        return role
 
     def remove(self, token: str) -> None:
         self.rdb.delete(self._key(token))

--- a/backends/python-fastapi/app/infrastructure/model/model.py
+++ b/backends/python-fastapi/app/infrastructure/model/model.py
@@ -71,6 +71,7 @@ class InvitationModel(Base):
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     token: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    role: Mapped[int] = mapped_column(Integer, nullable=False, default=2)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
 

--- a/backends/python-fastapi/app/infrastructure/model/model.py
+++ b/backends/python-fastapi/app/infrastructure/model/model.py
@@ -73,7 +73,12 @@ class InvitationModel(Base):
     token: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     role: Mapped[int] = mapped_column(Integer, nullable=False, default=2)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    created_by: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
+    updated_by: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    deleted_by: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
 
 
 class NotificationModel(Base):

--- a/backends/python-fastapi/app/infrastructure/persistence/sqlalchemy_invitation_repository.py
+++ b/backends/python-fastapi/app/infrastructure/persistence/sqlalchemy_invitation_repository.py
@@ -13,11 +13,12 @@ from app.domain.invitation.repository import InvitationRepository
 from app.infrastructure.model.model import InvitationModel
 
 
-def _build_vo(token: str, frontend_url: str) -> InvitationVo:
-    """トークンと URL から InvitationVo を構築します。
+def _build_vo(token: str, role: int, frontend_url: str) -> InvitationVo:
+    """トークン、ロール、URL から InvitationVo を構築します。
 
     Args:
         token: 招待トークン
+        role: ロール（1=管理者, 2=メンバー）
         frontend_url: フロントエンドのベース URL
 
     Returns:
@@ -25,7 +26,7 @@ def _build_vo(token: str, frontend_url: str) -> InvitationVo:
     """
     url = f"{frontend_url}/invitation/{token}"
     display_url = url.replace("https://", "").replace("http://", "")
-    return InvitationVo(token=token, url=url, display_url=display_url)
+    return InvitationVo(token=token, url=url, display_url=display_url, role=role)
 
 
 
@@ -47,28 +48,39 @@ class SqlAlchemyInvitationRepository(InvitationRepository):
         self.db = db
         self.frontend_url = frontend_url
 
-    def get_current(self) -> Optional[InvitationVo]:
-        """最新の招待情報のバリューオブジェクトを返します。
+    def get_current_by_role(self, role: int) -> Optional[InvitationVo]:
+        """ロールで絞り込んだ最新の招待情報のバリューオブジェクトを返します。
+
+        Args:
+            role: ロール（1=管理者, 2=メンバー）
 
         Returns:
             InvitationVo、または None
         """
-        m = self.db.query(InvitationModel).order_by(InvitationModel.id.desc()).first()
+        m = (
+            self.db.query(InvitationModel)
+            .filter(InvitationModel.role == role)
+            .order_by(InvitationModel.id.desc())
+            .first()
+        )
         if m is None:
             return None
-        return _build_vo(m.token, self.frontend_url)
+        return _build_vo(m.token, m.role, self.frontend_url)
 
-    def issue(self) -> InvitationVo:
+    def issue(self, role: int) -> InvitationVo:
         """新しい招待トークンを生成して保存し、バリューオブジェクトを返します。
+
+        Args:
+            role: ロール（1=管理者, 2=メンバー）
 
         Returns:
             InvitationVo インスタンス
         """
         token = secrets.token_hex(16)
-        m = InvitationModel(token=token)
+        m = InvitationModel(token=token, role=role)
         self.db.add(m)
         self.db.flush()
-        return _build_vo(token, self.frontend_url)
+        return _build_vo(token, role, self.frontend_url)
 
     def find_by_token(self, token: str) -> Optional[InvitationVo]:
         """トークンで招待情報のバリューオブジェクトを返します。
@@ -82,4 +94,4 @@ class SqlAlchemyInvitationRepository(InvitationRepository):
         m = self.db.query(InvitationModel).filter(InvitationModel.token == token).first()
         if m is None:
             return None
-        return _build_vo(m.token, self.frontend_url)
+        return _build_vo(m.token, m.role, self.frontend_url)

--- a/backends/python-fastapi/app/infrastructure/persistence/sqlalchemy_invitation_repository.py
+++ b/backends/python-fastapi/app/infrastructure/persistence/sqlalchemy_invitation_repository.py
@@ -68,7 +68,7 @@ class SqlAlchemyInvitationRepository(InvitationRepository):
         return _build_vo(m.token, m.role, self.frontend_url)
 
     def issue(self, role: int) -> InvitationVo:
-        """新しい招待トークンを生成して保存し、バリューオブジェクトを返します。
+        """既存の招待レコードのトークンを更新し、バリューオブジェクトを返します。
 
         Args:
             role: ロール（1=管理者, 2=メンバー）
@@ -76,9 +76,18 @@ class SqlAlchemyInvitationRepository(InvitationRepository):
         Returns:
             InvitationVo インスタンス
         """
+        m = (
+            self.db.query(InvitationModel)
+            .filter(InvitationModel.role == role)
+            .order_by(InvitationModel.id.desc())
+            .first()
+        )
         token = secrets.token_hex(16)
-        m = InvitationModel(token=token, role=role)
-        self.db.add(m)
+        if m is None:
+            m = InvitationModel(token=token, role=role)
+            self.db.add(m)
+        else:
+            m.token = token
         self.db.flush()
         return _build_vo(token, role, self.frontend_url)
 

--- a/backends/python-fastapi/app/routers/admin_invitations.py
+++ b/backends/python-fastapi/app/routers/admin_invitations.py
@@ -3,20 +3,34 @@
 
 Author: Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
 """
-from fastapi import APIRouter, Depends
-from app.routers.deps import get_invitation_interactor
+from fastapi import APIRouter, Depends, Query
+from app.exceptions import bad_request, unauthorized
+from app.routers.deps import get_invitation_interactor, get_staff_id_from_cookie
 from app.usecase.invitation.interactor import InvitationInteractor
 
 router = APIRouter()
 
 
 @router.get("/admin/invitation")
-def index(interactor: InvitationInteractor = Depends(get_invitation_interactor)):
-    result = interactor.current()
+def index(
+    role: int = Query(2),
+    interactor: InvitationInteractor = Depends(get_invitation_interactor),
+):
+    if role not in (1, 2):
+        raise bad_request("invalid_role")
+    result = interactor.current(role)
     return {"found": True, "url": result.url, "display_url": result.display_url, "token": result.token}
 
 
 @router.get("/admin/invitation/issue")
-def issue(interactor: InvitationInteractor = Depends(get_invitation_interactor)):
-    result = interactor.issue()
+def issue(
+    role: int = Query(2),
+    staff_id: int = Depends(get_staff_id_from_cookie),
+    interactor: InvitationInteractor = Depends(get_invitation_interactor),
+):
+    if staff_id == 0:
+        raise unauthorized("unauthenticated")
+    if role not in (1, 2):
+        raise bad_request("invalid_role")
+    result = interactor.issue(role)
     return {"found": True, "url": result.url, "display_url": result.display_url, "token": result.token}

--- a/backends/python-fastapi/app/usecase/auth/interactor.py
+++ b/backends/python-fastapi/app/usecase/auth/interactor.py
@@ -70,7 +70,8 @@ class AuthInteractor:
         staff = self.staff_repo.find_staff_by_provider(dto.provider, dto.provider_id)
         if staff is None:
             token = dto.invitation_token
-            if not token or self.invitation_auth_repo.find(token) is None:
+            role_value = self.invitation_auth_repo.find(token) if token else None
+            if role_value is None:
                 raise forbidden("invitation_required")
             self.invitation_auth_repo.remove(token)
             now = datetime.now(timezone.utc)
@@ -80,7 +81,7 @@ class AuthInteractor:
                 name=dto.name,
                 email=dto.email,
                 avatar=dto.avatar,
-                role=0,
+                role=role_value,
                 last_login_at=now,
             )
         else:

--- a/backends/python-fastapi/app/usecase/invitation/interactor.py
+++ b/backends/python-fastapi/app/usecase/invitation/interactor.py
@@ -27,8 +27,11 @@ class InvitationInteractor:
         self.invitation_repository = repo
         self.invitation_auth_repository = auth_repo
 
-    def current(self) -> InvitationVo:
-        """最新の招待情報の Vo を返します。
+    def current(self, role: int) -> InvitationVo:
+        """ロールで絞り込んだ最新の招待情報の Vo を返します。
+
+        Args:
+            role: ロール（1=管理者, 2=メンバー）
 
         Returns:
             InvitationVo インスタンス
@@ -36,21 +39,24 @@ class InvitationInteractor:
         Raises:
             AppException: 招待が存在しない場合
         """
-        result = self.invitation_repository.get_current()
+        result = self.invitation_repository.get_current_by_role(role)
         if result is None:
             raise not_found("invitation_not_found")
         return result
 
-    def issue(self) -> InvitationVo:
+    def issue(self, role: int) -> InvitationVo:
         """新しい招待トークンを発行し、招待情報の Vo を返します。
+
+        Args:
+            role: ロール（1=管理者, 2=メンバー）
 
         Returns:
             InvitationVo インスタンス
         """
-        return self.invitation_repository.issue()
+        return self.invitation_repository.issue(role)
 
     def find_by_token(self, token: str) -> InvitationVo:
-        """トークンで招待情報の Vo を返し、認証トークンをキャッシュします。
+        """トークンで招待情報の Vo を返し、認証トークンとロールをキャッシュします。
 
         Args:
             token: 招待トークン
@@ -64,5 +70,5 @@ class InvitationInteractor:
         result = self.invitation_repository.find_by_token(token)
         if result is None:
             raise not_found("invitation_not_found")
-        self.invitation_auth_repository.store(result.token, 600)
+        self.invitation_auth_repository.store(result.token, result.role, 600)
         return result

--- a/backends/python-fastapi/tests/test_admin_invitations.py
+++ b/backends/python-fastapi/tests/test_admin_invitations.py
@@ -1,29 +1,51 @@
 """管理招待エンドポイントのテスト。"""
 
-from tests.conftest import make_invitation
+from tests.conftest import make_invitation, make_staff
 
 
 class TestAdminInvitationIndex:
     def test_現在の招待URLが取得できる(self, client, db_session):
-        inv = make_invitation(db_session, token="current-token")
-        res = client.get("/api/admin/invitation")
+        inv = make_invitation(db_session, token="current-token", role=2)
+        res = client.get("/api/admin/invitation?role=2")
         assert res.status_code == 200
         data = res.json()
         assert data["token"] == inv.token
         assert "url" in data
 
+    def test_roleパラメータが不正な場合400が返る(self, client):
+        res = client.get("/api/admin/invitation?role=3")
+        assert res.status_code == 400
+
+    def test_管理者ロールで招待URLが取得できる(self, client, db_session):
+        inv = make_invitation(db_session, token="admin-token", role=1)
+        res = client.get("/api/admin/invitation?role=1")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["token"] == inv.token
+
 
 class TestAdminInvitationIssue:
-    def test_招待URLが発行できる(self, client):
-        res = client.get("/api/admin/invitation/issue")
+    def test_招待URLが発行できる(self, client, db_session):
+        staff = make_staff(db_session)
+        res = client.get("/api/admin/invitation/issue?role=2", cookies={"staff_id": str(staff.id)})
         assert res.status_code == 200
         data = res.json()
         assert "url" in data
         assert "token" in data
 
     def test_再発行で新しいトークンが返る(self, client, db_session):
-        make_invitation(db_session, token="old-token")
-        res = client.get("/api/admin/invitation/issue")
+        staff = make_staff(db_session)
+        make_invitation(db_session, token="old-token", role=2)
+        res = client.get("/api/admin/invitation/issue?role=2", cookies={"staff_id": str(staff.id)})
         assert res.status_code == 200
         data = res.json()
         assert data["token"] != "old-token"
+
+    def test_未認証で401が返る(self, client):
+        res = client.get("/api/admin/invitation/issue?role=2")
+        assert res.status_code == 401
+
+    def test_roleパラメータが不正な場合400が返る(self, client, db_session):
+        staff = make_staff(db_session)
+        res = client.get("/api/admin/invitation/issue?role=3", cookies={"staff_id": str(staff.id)})
+        assert res.status_code == 400

--- a/backends/ruby-hanami/app/actions/admin/invitations/index.rb
+++ b/backends/ruby-hanami/app/actions/admin/invitations/index.rb
@@ -17,8 +17,23 @@ module Authorization
           # @param response [Hanami::Action::Response] レスポンス
           # @return [void]
           def handle(request, response)
-            v = container[:invitation_uc].current
+            role = resolve_role(request, response)
+            return unless role
+
+            v = container[:invitation_uc].current(role)
             json_response(response, { found: true, url: v.url, display_url: v.display_url, token: v.token })
+          end
+
+          private
+
+          def resolve_role(request, response)
+            role = request.params[:role].to_s
+            role = role.empty? ? 2 : role.to_i
+            unless [1, 2].include?(role)
+              json_response(response, { error: "invalid_role" }, status: 400)
+              return nil
+            end
+            role
           end
         end
       end

--- a/backends/ruby-hanami/app/actions/admin/invitations/index.rb
+++ b/backends/ruby-hanami/app/actions/admin/invitations/index.rb
@@ -27,8 +27,17 @@ module Authorization
           private
 
           def resolve_role(request, response)
-            role = request.params[:role].to_s
-            role = role.empty? ? 2 : role.to_i
+            role_str = request.params[:role].to_s
+            if role_str.empty?
+              role = 2
+            else
+              begin
+                role = Integer(role_str)
+              rescue ArgumentError
+                json_response(response, { error: "invalid_role" }, status: 400)
+                return nil
+              end
+            end
             unless [1, 2].include?(role)
               json_response(response, { error: "invalid_role" }, status: 400)
               return nil

--- a/backends/ruby-hanami/app/actions/admin/invitations/issue.rb
+++ b/backends/ruby-hanami/app/actions/admin/invitations/issue.rb
@@ -30,8 +30,17 @@ module Authorization
           private
 
           def resolve_role(request, response)
-            role = request.params[:role].to_s
-            role = role.empty? ? 2 : role.to_i
+            role_str = request.params[:role].to_s
+            if role_str.empty?
+              role = 2
+            else
+              begin
+                role = Integer(role_str)
+              rescue ArgumentError
+                json_response(response, { error: "invalid_role" }, status: 400)
+                return nil
+              end
+            end
             unless [1, 2].include?(role)
               json_response(response, { error: "invalid_role" }, status: 400)
               return nil

--- a/backends/ruby-hanami/app/actions/admin/invitations/issue.rb
+++ b/backends/ruby-hanami/app/actions/admin/invitations/issue.rb
@@ -17,8 +17,26 @@ module Authorization
           # @param response [Hanami::Action::Response] レスポンス
           # @return [void]
           def handle(request, response)
-            v = transaction { container[:invitation_uc].issue }
+            staff_id = staff_id_from_cookie(request)
+            return json_response(response, { error: "unauthenticated" }, status: 401) if staff_id == 0
+
+            role = resolve_role(request, response)
+            return unless role
+
+            v = transaction { container[:invitation_uc].issue(role) }
             json_response(response, { found: true, url: v.url, display_url: v.display_url, token: v.token })
+          end
+
+          private
+
+          def resolve_role(request, response)
+            role = request.params[:role].to_s
+            role = role.empty? ? 2 : role.to_i
+            unless [1, 2].include?(role)
+              json_response(response, { error: "invalid_role" }, status: 400)
+              return nil
+            end
+            role
           end
         end
       end

--- a/backends/ruby-hanami/app/config/container.rb
+++ b/backends/ruby-hanami/app/config/container.rb
@@ -18,7 +18,7 @@ module AppContainer
 
     client_repo       = Infrastructure::Persistence::RomClientRepository.new(rom)
     staff_repo        = Infrastructure::Persistence::RomStaffRepository.new(rom)
-    invitation_repo   = Infrastructure::Persistence::RomInvitationRepository.new(rom, cfg)
+    invitation_repo   = Infrastructure::Persistence::RomInvitationRepository.new(rom)
     notification_repo = Infrastructure::Persistence::RomNotificationRepository.new(rom)
     gate_cache            = Infrastructure::Cache::RedisGateRepository.new(cfg)
     invitation_auth_cache = Infrastructure::Cache::RedisInvitationAuthRepository.new(cfg)
@@ -30,7 +30,7 @@ module AppContainer
       auth_uc:         UseCase::Auth::Interactor.new(staff_repo, invitation_auth_cache),
       client_uc:       UseCase::Client::Interactor.new(client_repo),
       staff_uc:        UseCase::Staff::Interactor.new(staff_repo),
-      invitation_uc:   UseCase::Invitation::Interactor.new(invitation_repo, invitation_auth_cache),
+      invitation_uc:   UseCase::Invitation::Interactor.new(invitation_repo, invitation_auth_cache, cfg.app.frontend_url),
       gate_uc:         UseCase::Gate::Interactor.new(client_repo, gate_cache, cfg),
       notification_uc: UseCase::Notification::Interactor.new(notification_repo, staff_repo),
       mailer:          mailer,

--- a/backends/ruby-hanami/app/domain/errors.rb
+++ b/backends/ruby-hanami/app/domain/errors.rb
@@ -5,6 +5,26 @@
 # @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
 
 module Domain
+  # HTTP 400 Bad Request に対応するアプリケーション例外です。
+  class BadRequestError < StandardError
+    attr_reader :code
+
+    def initialize(msg = "bad_request")
+      super(msg)
+      @code = 400
+    end
+  end
+
+  # HTTP 401 Unauthorized に対応するアプリケーション例外です。
+  class UnauthorizedError < StandardError
+    attr_reader :code
+
+    def initialize(msg = "unauthenticated")
+      super(msg)
+      @code = 401
+    end
+  end
+
   # HTTP 403 Forbidden に対応するアプリケーション例外です。
   class ForbiddenError < StandardError
     attr_reader :code

--- a/backends/ruby-hanami/app/domain/invitation/auth_repository.rb
+++ b/backends/ruby-hanami/app/domain/invitation/auth_repository.rb
@@ -10,10 +10,11 @@ module Domain
     # @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
     module AuthRepository
       # @param token [String] 招待トークン
+      # @param role [Integer] ロール（1=管理者, 2=メンバー）
       # @param ttl [Integer] キャッシュ有効期間（秒）
-      def store(token, ttl) = raise NotImplementedError
+      def store(token, role, ttl) = raise NotImplementedError
       # @param token [String] 招待トークン
-      # @return [String, nil] トークン文字列、または nil
+      # @return [Integer, nil] ロール値、または nil
       def find(token) = raise NotImplementedError
       # @param token [String] 招待トークン
       def remove(token) = raise NotImplementedError

--- a/backends/ruby-hanami/app/domain/invitation/entity.rb
+++ b/backends/ruby-hanami/app/domain/invitation/entity.rb
@@ -8,7 +8,7 @@ module Domain
   module Invitation
     # 招待のエンティティです。
     Entity = Struct.new(
-      :id, :token,
+      :id, :token, :role,
       :created_at, :created_by, :updated_at, :updated_by,
       :deleted_at, :deleted_by, :version,
       keyword_init: true

--- a/backends/ruby-hanami/app/domain/invitation/repository.rb
+++ b/backends/ruby-hanami/app/domain/invitation/repository.rb
@@ -8,15 +8,17 @@ module Domain
   module Invitation
     # 招待リポジトリのインターフェースです。
     module Repository
+      # @param role [Integer] ロール（1=管理者, 2=メンバー）
       # @return [Domain::Invitation::Entity, nil] 現在有効な招待エンティティ
-      def get_current             = raise NotImplementedError
+      def get_current_by_role(role) = raise NotImplementedError
 
+      # @param role [Integer] ロール（1=管理者, 2=メンバー）
       # @return [Domain::Invitation::Entity] 発行した招待エンティティ
-      def issue                   = raise NotImplementedError
+      def issue(role)               = raise NotImplementedError
 
       # @param token [String] 招待トークン
       # @return [Domain::Invitation::Entity, nil] 招待エンティティ
-      def find_by_token(token)    = raise NotImplementedError
+      def find_by_token(token)      = raise NotImplementedError
     end
   end
 end

--- a/backends/ruby-hanami/app/infrastructure/cache/redis_invitation_auth_repository.rb
+++ b/backends/ruby-hanami/app/infrastructure/cache/redis_invitation_auth_repository.rb
@@ -17,13 +17,14 @@ module Infrastructure
         @prefix = cfg.app.cache_prefix
       end
 
-      def store(token, ttl)
-        @redis.set(cache_key(token), token, ex: ttl)
+      def store(token, role, ttl)
+        @redis.set(cache_key(token), role.to_s, ex: ttl)
         nil
       end
 
       def find(token)
-        @redis.get(cache_key(token))
+        value = @redis.get(cache_key(token))
+        value&.match?(/\A\d+\z/) ? value.to_i : nil
       end
 
       def remove(token)

--- a/backends/ruby-hanami/app/infrastructure/persistence/rom_invitation_repository.rb
+++ b/backends/ruby-hanami/app/infrastructure/persistence/rom_invitation_repository.rb
@@ -5,48 +5,35 @@ require "securerandom"
 module Infrastructure
   module Persistence
     class RomInvitationRepository
-      def initialize(rom, cfg = nil)
-        @ds           = rom.gateways[:default].connection[:invitations]
-        @frontend_url = cfg&.app&.frontend_url || ENV.fetch("FRONTEND_URL", "http://localhost:3000")
+      def initialize(rom)
+        @ds = rom.gateways[:default].connection[:invitations]
       end
 
-      def get_current
-        r = @ds.where(deleted_at: nil).order(Sequel.desc(:created_at)).first
-        r ? build_vo(r[:token]) : nil
+      def get_current_by_role(role)
+        r = @ds.where(deleted_at: nil, role: role).order(Sequel.desc(:created_at)).first
+        r ? build_entity(r) : nil
       end
 
-      def issue
+      def issue(role)
         token = SecureRandom.hex(16)
         now   = Time.now
-        @ds.insert(token: token, created_at: now, created_by: 0, updated_at: now, updated_by: 0)
-        build_vo(token)
+        @ds.insert(token: token, role: role, created_at: now, created_by: 0, updated_at: now, updated_by: 0)
+        build_entity(@ds.where(token: token).first)
       end
 
       def find_by_token(token)
         r = @ds.where(token: token, deleted_at: nil).first
-        r ? build_vo(r[:token]) : nil
+        r ? build_entity(r) : nil
       end
 
       private
 
-      def build_vo(token)
-        url         = "#{@frontend_url}/invitation/#{token}"
-        display_url = build_display_url(url)
-        Domain::Invitation::Vo.new(token: token, url: url, display_url: display_url)
-      end
-
-      def build_display_url(url)
-        seg = "/invitation/"
-        idx = url.index(seg)
-        if idx
-          base   = url[0, idx + seg.length]
-          after  = url[idx + seg.length..]
-          tok_end = (after.index(/[?#]/) || after.length)
-          tok    = after[0, tok_end]
-          suffix = after[tok_end..]
-          return "#{base}#{tok[0, 6]}...#{tok[-4..]}#{suffix}" if tok.length > 13
-        end
-        url.length > 72 ? "#{url[0, 68]}..." : url
+      def build_entity(r)
+        Domain::Invitation::Entity.new(
+          id:    r[:id],
+          token: r[:token],
+          role:  r[:role],
+        )
       end
     end
   end

--- a/backends/ruby-hanami/app/usecase/auth/interactor.rb
+++ b/backends/ruby-hanami/app/usecase/auth/interactor.rb
@@ -34,7 +34,8 @@ module UseCase
           saved = @staff_repo.save(updated)
         else
           token = dto.invitation_token
-          if token.nil? || token.empty? || @invitation_auth_repo.find(token).nil?
+          role_value = (token.nil? || token.empty?) ? nil : @invitation_auth_repo.find(token)
+          if role_value.nil?
             raise Domain::ForbiddenError.new("invitation_required")
           end
           @invitation_auth_repo.remove(token)
@@ -45,7 +46,7 @@ module UseCase
             provider:      dto.provider,
             provider_id:   dto.provider_id,
             avatar:        dto.avatar,
-            role:          Domain::Staff::Role::MEMBER,
+            role:          role_value,
             last_login_at: now,
             created_at:    now,
             created_by:    0,

--- a/backends/ruby-hanami/app/usecase/invitation/interactor.rb
+++ b/backends/ruby-hanami/app/usecase/invitation/interactor.rb
@@ -11,24 +11,56 @@ module UseCase
     class Interactor
       # @param invitation_repo [Domain::Invitation::Repository] 招待リポジトリ
       # @param invitation_auth_repo [Domain::Invitation::AuthRepository] 招待認証キャッシュリポジトリ
-      def initialize(invitation_repo, invitation_auth_repo)
+      # @param frontend_url [String] フロントエンド URL
+      def initialize(invitation_repo, invitation_auth_repo, frontend_url = ENV.fetch("FRONTEND_URL", "http://localhost:3000"))
         @invitation_repo      = invitation_repo
         @invitation_auth_repo = invitation_auth_repo
+        @frontend_url         = frontend_url
       end
 
-      def current
-        @invitation_repo.get_current
+      # @param role [Integer] ロール（1=管理者, 2=メンバー）
+      # @return [Domain::Invitation::Vo, nil] 招待値オブジェクト
+      def current(role)
+        entity = @invitation_repo.get_current_by_role(role)
+        entity ? entity_to_vo(entity) : nil
       end
 
-      def issue
-        @invitation_repo.issue
+      # @param role [Integer] ロール（1=管理者, 2=メンバー）
+      # @return [Domain::Invitation::Vo] 発行した招待値オブジェクト
+      def issue(role)
+        entity = @invitation_repo.issue(role)
+        entity_to_vo(entity)
       end
 
+      # @param dto [UseCase::Invitation::FindByTokenDto] トークン検索 DTO
+      # @return [Domain::Invitation::Vo] 招待値オブジェクト
       def find_by_token(dto)
-        vo = @invitation_repo.find_by_token(dto.token)
-        raise "invitation_not_found" unless vo
-        @invitation_auth_repo.store(vo.token, 600)
-        vo
+        entity = @invitation_repo.find_by_token(dto.token)
+        raise "invitation_not_found" unless entity
+        @invitation_auth_repo.store(entity.token, entity.role, 600)
+        entity_to_vo(entity)
+      end
+
+      private
+
+      def entity_to_vo(entity)
+        url         = "#{@frontend_url}/invitation/#{entity.token}"
+        display_url = build_display_url(url)
+        Domain::Invitation::Vo.new(token: entity.token, url: url, display_url: display_url)
+      end
+
+      def build_display_url(url)
+        seg = "/invitation/"
+        idx = url.index(seg)
+        if idx
+          base    = url[0, idx + seg.length]
+          after   = url[idx + seg.length..]
+          tok_end = (after.index(/[?#]/) || after.length)
+          tok     = after[0, tok_end]
+          suffix  = after[tok_end..]
+          return "#{base}#{tok[0, 6]}...#{tok[-4..]}#{suffix}" if tok.length > 13
+        end
+        url.length > 72 ? "#{url[0, 68]}..." : url
       end
     end
   end

--- a/backends/ruby-hanami/db/migrate/20260516000000_add_role_to_invitations.rb
+++ b/backends/ruby-hanami/db/migrate/20260516000000_add_role_to_invitations.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+#
+# invitations テーブルに role カラムを追加するマイグレーション。
+#
+# @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
+
+# invitations テーブルに role（権限）カラムを追加します。
+Sequel.migration do
+  up do
+    alter_table(:invitations) do
+      add_column :role, Integer, unsigned: true, null: false, default: 2, after: :token
+    end
+  end
+
+  down do
+    alter_table(:invitations) do
+      drop_column :role
+    end
+  end
+end

--- a/backends/ruby-hanami/spec/requests/admin/invitations_spec.rb
+++ b/backends/ruby-hanami/spec/requests/admin/invitations_spec.rb
@@ -6,23 +6,60 @@ RSpec.describe "Admin::Invitations" do
   before { truncate_tables }
 
   describe "GET /api/admin/invitation" do
-    it "現在の招待情報を返す" do
-      inv = create_invitation
+    it "デフォルト(role=2)で現在の招待情報を返す" do
+      inv = create_invitation(role: 2)
       get "/api/admin/invitation"
       expect(last_response.status).to eq(200)
       body = JSON.parse(last_response.body)
       expect(body["found"]).to be true
       expect(body["token"]).to eq(inv[:token].to_s)
     end
+
+    it "role=1 で管理者招待情報を返す" do
+      inv = create_invitation(role: 1)
+      get "/api/admin/invitation?role=1"
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body["found"]).to be true
+      expect(body["token"]).to eq(inv[:token].to_s)
+    end
+
+    it "role が不正な値なら 400 を返す" do
+      get "/api/admin/invitation?role=3"
+      expect(last_response.status).to eq(400)
+    end
   end
 
   describe "GET /api/admin/invitation/issue" do
-    it "新しい招待を発行して返す" do
+    it "認証クッキーがなければ 401 を返す" do
+      get "/api/admin/invitation/issue"
+      expect(last_response.status).to eq(401)
+    end
+
+    it "認証クッキーがあれば新しい招待を発行して返す" do
+      staff = create_staff
+      set_cookie "staff_id=#{staff[:id]}"
       get "/api/admin/invitation/issue"
       expect(last_response.status).to eq(200)
       body = JSON.parse(last_response.body)
       expect(body["found"]).to be true
       expect(body["token"]).not_to be_nil
+    end
+
+    it "role=1 で管理者招待を発行する" do
+      staff = create_staff
+      set_cookie "staff_id=#{staff[:id]}"
+      get "/api/admin/invitation/issue?role=1"
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body["found"]).to be true
+    end
+
+    it "role が不正な値なら 400 を返す" do
+      staff = create_staff
+      set_cookie "staff_id=#{staff[:id]}"
+      get "/api/admin/invitation/issue?role=0"
+      expect(last_response.status).to eq(400)
     end
   end
 end

--- a/backends/ruby-hanami/spec/spec_helper.rb
+++ b/backends/ruby-hanami/spec/spec_helper.rb
@@ -149,10 +149,11 @@ def create_client(overrides = {})
   db[:clients].where(id: id).first
 end
 
-def create_invitation(token = SecureRandom.hex(16))
+def create_invitation(token = SecureRandom.hex(16), role: 2)
   now = Time.now
   id = db[:invitations].insert(
     token:      token,
+    role:       role,
     created_at: now,
     updated_at: now,
     created_by: 0,

--- a/backends/ruby-hanami/spec/usecase/auth/interactor_spec.rb
+++ b/backends/ruby-hanami/spec/usecase/auth/interactor_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe UseCase::Auth::Interactor do
   end
 
   let(:stub_auth_repo) do
-    double("InvitationAuthRepo", find: "tok", remove: nil)
+    double("InvitationAuthRepo", find: Domain::Staff::Role::MEMBER, remove: nil)
   end
 
   describe "#find_user" do
@@ -40,7 +40,7 @@ RSpec.describe UseCase::Auth::Interactor do
   end
 
   describe "#login" do
-    it "returns Vo for new staff (upsert)" do
+    it "returns Vo for new staff with role from invitation cache" do
       allow(stub_repo).to receive(:find_by_provider).and_return(nil)
       allow(stub_repo).to receive(:save).and_return(staff_entity)
       dto = UseCase::Auth::LoginDto.new(
@@ -49,6 +49,18 @@ RSpec.describe UseCase::Auth::Interactor do
       )
       vo = described_class.new(stub_repo, stub_auth_repo).login(dto)
       expect(vo.id).to eq 1
+    end
+
+    it "raises ForbiddenError when invitation cache returns nil" do
+      allow(stub_repo).to receive(:find_by_provider).and_return(nil)
+      allow(stub_auth_repo).to receive(:find).and_return(nil)
+      dto = UseCase::Auth::LoginDto.new(
+        provider: 1, provider_id: "g123",
+        name: "テスト", email: "t@example.com", avatar: "http://img", invitation_token: "bad"
+      )
+      expect {
+        described_class.new(stub_repo, stub_auth_repo).login(dto)
+      }.to raise_error(Domain::ForbiddenError)
     end
 
     it "returns Vo for existing staff (update)" do

--- a/backends/ruby-hanami/spec/usecase/invitation/interactor_spec.rb
+++ b/backends/ruby-hanami/spec/usecase/invitation/interactor_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe UseCase::Invitation::Interactor do
 
   describe "#issue" do
     it "returns newly issued invitation" do
+      expect(stub_repo).to receive(:issue).with(2).and_return(make_entity.call("new-token"))
       vo = described_class.new(stub_repo, stub_auth_repo, frontend_url).issue(2)
       expect(vo.token).to eq "new-token"
     end

--- a/backends/ruby-hanami/spec/usecase/invitation/interactor_spec.rb
+++ b/backends/ruby-hanami/spec/usecase/invitation/interactor_spec.rb
@@ -3,21 +3,27 @@
 require "spec_helper"
 
 RSpec.describe UseCase::Invitation::Interactor do
+  let(:make_entity) do
+    ->(token = "tok123", role = 2) {
+      Domain::Invitation::Entity.new(id: 1, token: token, role: role)
+    }
+  end
+
   let(:make_vo) do
     ->(token = "tok123") {
       Domain::Invitation::Vo.new(
         token:       token,
-        url:         "http://localhost:3000/register?token=#{token}",
-        display_url: "http://localhost:3000/register?token=#{token}",
+        url:         "http://localhost:3000/invitation/#{token}",
+        display_url: "http://localhost:3000/invitation/#{token}",
       )
     }
   end
 
   let(:stub_repo) do
     double("InvitationRepo",
-      get_current:   make_vo.call,
-      issue:         make_vo.call("new-token"),
-      find_by_token: nil,
+      get_current_by_role: make_entity.call,
+      issue:               make_entity.call("new-token"),
+      find_by_token:       nil,
     )
   end
 
@@ -25,37 +31,40 @@ RSpec.describe UseCase::Invitation::Interactor do
     double("InvitationAuthRepo", store: nil)
   end
 
+  let(:frontend_url) { "http://localhost:3000" }
+
   describe "#current" do
     it "returns current invitation from repo" do
-      vo = described_class.new(stub_repo, stub_auth_repo).current
+      vo = described_class.new(stub_repo, stub_auth_repo, frontend_url).current(2)
       expect(vo.token).to eq "tok123"
     end
 
     it "returns nil when no invitation" do
-      allow(stub_repo).to receive(:get_current).and_return(nil)
-      expect(described_class.new(stub_repo, stub_auth_repo).current).to be_nil
+      allow(stub_repo).to receive(:get_current_by_role).and_return(nil)
+      expect(described_class.new(stub_repo, stub_auth_repo, frontend_url).current(2)).to be_nil
     end
   end
 
   describe "#issue" do
     it "returns newly issued invitation" do
-      vo = described_class.new(stub_repo, stub_auth_repo).issue
+      vo = described_class.new(stub_repo, stub_auth_repo, frontend_url).issue(2)
       expect(vo.token).to eq "new-token"
     end
   end
 
   describe "#find_by_token" do
-    it "returns vo when token found" do
-      vo = make_vo.call("abc")
-      allow(stub_repo).to receive(:find_by_token).with("abc").and_return(vo)
-      result = described_class.new(stub_repo, stub_auth_repo).find_by_token(UseCase::Invitation::FindByTokenDto.new(token: "abc"))
+    it "stores token and role in auth repo, returns vo" do
+      entity = make_entity.call("abc", 1)
+      allow(stub_repo).to receive(:find_by_token).with("abc").and_return(entity)
+      expect(stub_auth_repo).to receive(:store).with("abc", 1, 600)
+      result = described_class.new(stub_repo, stub_auth_repo, frontend_url).find_by_token(UseCase::Invitation::FindByTokenDto.new(token: "abc"))
       expect(result.token).to eq "abc"
     end
 
     it "raises when token not found" do
       allow(stub_repo).to receive(:find_by_token).and_return(nil)
       expect {
-        described_class.new(stub_repo, stub_auth_repo).find_by_token(UseCase::Invitation::FindByTokenDto.new(token: "bad"))
+        described_class.new(stub_repo, stub_auth_repo, frontend_url).find_by_token(UseCase::Invitation::FindByTokenDto.new(token: "bad"))
       }.to raise_error(RuntimeError)
     end
   end

--- a/backends/ruby-rails/app/controllers/api/admin/invitations_controller.rb
+++ b/backends/ruby-rails/app/controllers/api/admin/invitations_controller.rb
@@ -9,15 +9,37 @@
 class Api::Admin::InvitationsController < Api::BaseController
   # 現在有効な招待情報を返します。
   def index
-    v = container[:invitation_uc].current
+    role = resolve_role
+    return if performed?
+    v = container[:invitation_uc].current(role)
     render json: { found: true, url: v.url, display_url: v.display_url, token: v.token }
   end
 
   # 新しい招待を発行します。
   def issue
+    if staff_id_from_cookie == 0
+      return render json: { error: "unauthenticated" }, status: :unauthorized
+    end
+
+    role = resolve_role
+    return if performed?
+
     v = ActiveRecord::Base.transaction do
-      container[:invitation_uc].issue
+      container[:invitation_uc].issue(role)
     end
     render json: { found: true, url: v.url, display_url: v.display_url, token: v.token }
+  end
+
+  private
+
+  # クエリパラメーターから role を取得します（1 or 2、それ以外は 400）。
+  # @return [Integer] 権限（1=管理者, 2=メンバー）
+  def resolve_role
+    role = params[:role].presence ? params[:role].to_i : 2
+    unless [1, 2].include?(role)
+      render json: { error: "invalid_role" }, status: :bad_request
+      return
+    end
+    role
   end
 end

--- a/backends/ruby-rails/app/domain/invitation/auth_repository.rb
+++ b/backends/ruby-rails/app/domain/invitation/auth_repository.rb
@@ -10,10 +10,11 @@ module Domain
     # @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
     module AuthRepository
       # @param token [String] 招待トークン
+      # @param role [Integer] ロール（1=管理者, 2=メンバー）
       # @param ttl [Integer] キャッシュ有効期間（秒）
-      def store(token, ttl) = raise NotImplementedError
+      def store(token, role, ttl) = raise NotImplementedError
       # @param token [String] 招待トークン
-      # @return [String, nil] トークン文字列、または nil
+      # @return [Integer, nil] ロール値、または nil
       def find(token) = raise NotImplementedError
       # @param token [String] 招待トークン
       def remove(token) = raise NotImplementedError

--- a/backends/ruby-rails/app/domain/invitation/entity.rb
+++ b/backends/ruby-rails/app/domain/invitation/entity.rb
@@ -8,7 +8,7 @@ module Domain
   module Invitation
     # 招待のエンティティです。
     Entity = Struct.new(
-      :id, :token,
+      :id, :token, :role,
       :created_at, :created_by, :updated_at, :updated_by,
       :deleted_at, :deleted_by, :version,
       keyword_init: true

--- a/backends/ruby-rails/app/domain/invitation/repository.rb
+++ b/backends/ruby-rails/app/domain/invitation/repository.rb
@@ -8,15 +8,17 @@ module Domain
   module Invitation
     # 招待リポジトリのインターフェースです。
     module Repository
+      # @param role [Integer] ロール（1=管理者, 2=メンバー）
       # @return [Domain::Invitation::Entity, nil] 現在有効な招待エンティティ
-      def get_current             = raise NotImplementedError
+      def get_current_by_role(role) = raise NotImplementedError
 
+      # @param role [Integer] ロール（1=管理者, 2=メンバー）
       # @return [Domain::Invitation::Entity] 発行した招待エンティティ
-      def issue                   = raise NotImplementedError
+      def issue(role)               = raise NotImplementedError
 
       # @param token [String] 招待トークン
       # @return [Domain::Invitation::Entity, nil] 招待エンティティ
-      def find_by_token(token)    = raise NotImplementedError
+      def find_by_token(token)      = raise NotImplementedError
     end
   end
 end

--- a/backends/ruby-rails/app/infrastructure/cache/redis_invitation_auth_repository.rb
+++ b/backends/ruby-rails/app/infrastructure/cache/redis_invitation_auth_repository.rb
@@ -17,13 +17,14 @@ module Infrastructure
         @prefix = cfg.app.cache_prefix
       end
 
-      def store(token, ttl)
-        @redis.set(cache_key(token), token, ex: ttl)
+      def store(token, role, ttl)
+        @redis.set(cache_key(token), role.to_s, ex: ttl)
         nil
       end
 
       def find(token)
-        @redis.get(cache_key(token))
+        value = @redis.get(cache_key(token))
+        value&.match?(/\A\d+\z/) ? value.to_i : nil
       end
 
       def remove(token)

--- a/backends/ruby-rails/app/infrastructure/persistence/active_record_invitation_repository.rb
+++ b/backends/ruby-rails/app/infrastructure/persistence/active_record_invitation_repository.rb
@@ -24,7 +24,12 @@ module Infrastructure
       def issue(role)
         token = SecureRandom.hex(16)
         now   = Time.current
-        r = @model.create!(token: token, role: role, created_at: now, created_by: 0, updated_at: now, updated_by: 0)
+        r = @model.where(deleted_at: nil, role: role).order(created_at: :desc).first
+        if r.nil?
+          r = @model.create!(token: token, role: role, created_at: now, created_by: 0, updated_at: now, updated_by: 0)
+        else
+          r.update!(token: token, updated_at: now)
+        end
         build_entity(r)
       end
 

--- a/backends/ruby-rails/app/infrastructure/persistence/active_record_invitation_repository.rb
+++ b/backends/ruby-rails/app/infrastructure/persistence/active_record_invitation_repository.rb
@@ -16,24 +16,36 @@ module Infrastructure
         @frontend_url = cfg.app.frontend_url
       end
 
-      def get_current
-        r = @model.where(deleted_at: nil).order(created_at: :desc).first
-        r ? build_vo(r.token) : nil
+      def get_current_by_role(role)
+        r = @model.where(deleted_at: nil, role: role).order(created_at: :desc).first
+        r ? build_entity(r) : nil
       end
 
-      def issue
+      def issue(role)
         token = SecureRandom.hex(16)
         now   = Time.current
-        @model.create!(token: token, created_at: now, created_by: 0, updated_at: now, updated_by: 0)
-        build_vo(token)
+        r = @model.create!(token: token, role: role, created_at: now, created_by: 0, updated_at: now, updated_by: 0)
+        build_entity(r)
       end
 
       def find_by_token(token)
         r = @model.find_by(token: token, deleted_at: nil)
-        r ? build_vo(r.token) : nil
+        r ? build_entity(r) : nil
+      end
+
+      def entity_to_vo(entity)
+        build_vo(entity.token)
       end
 
       private
+
+      def build_entity(record)
+        Domain::Invitation::Entity.new(
+          id:    record.id,
+          token: record.token,
+          role:  record.role,
+        )
+      end
 
       def build_vo(token)
         url         = "#{@frontend_url}/invitation/#{token}"

--- a/backends/ruby-rails/app/usecase/auth/interactor.rb
+++ b/backends/ruby-rails/app/usecase/auth/interactor.rb
@@ -34,7 +34,8 @@ module UseCase
           saved = @staff_repo.save(updated)
         else
           token = dto.invitation_token
-          if token.blank? || @invitation_auth_repo.find(token).nil?
+          role_value = token.blank? ? nil : @invitation_auth_repo.find(token)
+          if role_value.nil?
             raise Domain::ForbiddenError.new("invitation_required")
           end
           @invitation_auth_repo.remove(token)
@@ -45,7 +46,7 @@ module UseCase
             provider:      dto.provider,
             provider_id:   dto.provider_id,
             avatar:        dto.avatar,
-            role:          Domain::Staff::Role::MEMBER,
+            role:          role_value,
             last_login_at: now,
             created_at:    now,
             created_by:    nil,

--- a/backends/ruby-rails/app/usecase/invitation/interactor.rb
+++ b/backends/ruby-rails/app/usecase/invitation/interactor.rb
@@ -16,19 +16,21 @@ module UseCase
         @invitation_auth_repo = invitation_auth_repo
       end
 
-      def current
-        @invitation_repo.get_current
+      def current(role)
+        entity = @invitation_repo.get_current_by_role(role)
+        entity ? @invitation_repo.entity_to_vo(entity) : nil
       end
 
-      def issue
-        @invitation_repo.issue
+      def issue(role)
+        entity = @invitation_repo.issue(role)
+        @invitation_repo.entity_to_vo(entity)
       end
 
       def find_by_token(dto)
-        vo = @invitation_repo.find_by_token(dto.token)
-        raise "invitation_not_found" unless vo
-        @invitation_auth_repo.store(vo.token, 600)
-        vo
+        entity = @invitation_repo.find_by_token(dto.token)
+        raise "invitation_not_found" unless entity
+        @invitation_auth_repo.store(entity.token, entity.role, 600)
+        @invitation_repo.entity_to_vo(entity)
       end
     end
   end

--- a/backends/ruby-rails/db/migrate/20260516000000_add_role_to_invitations.rb
+++ b/backends/ruby-rails/db/migrate/20260516000000_add_role_to_invitations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+#
+# invitations テーブルに role カラムを追加するマイグレーション。
+#
+# @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
+
+# invitations テーブルに role（権限）カラムを追加します。
+class AddRoleToInvitations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :invitations, :role, :integer, unsigned: true, null: false, default: 2, after: :token, comment: "権限"
+  end
+end

--- a/backends/ruby-rails/spec/rails_helper.rb
+++ b/backends/ruby-rails/spec/rails_helper.rb
@@ -92,10 +92,11 @@ RSpec.configure do |config|
       }.merge(overrides))
     end
 
-    def create_invitation(token = SecureRandom.hex(16))
+    def create_invitation(token = SecureRandom.hex(16), role = 2)
       now = Time.current
       Infrastructure::Model::Invitation.create!(
         token:      token,
+        role:       role,
         created_at: now,
         updated_at: now,
       )

--- a/backends/ruby-rails/spec/requests/admin/invitations_spec.rb
+++ b/backends/ruby-rails/spec/requests/admin/invitations_spec.rb
@@ -29,7 +29,13 @@ RSpec.describe "Admin::Invitations", type: :request do
   end
 
   describe "GET /api/admin/invitation/issue" do
+    it "認証なしで 401 を返す" do
+      get "/api/admin/invitation/issue"
+      expect(response).to have_http_status(401)
+    end
+
     it "新しい招待を発行して返す（デフォルト role=2）" do
+      cookies[:staff_id] = "1"
       get "/api/admin/invitation/issue"
       expect(response).to have_http_status(200)
       body = JSON.parse(response.body)
@@ -38,6 +44,7 @@ RSpec.describe "Admin::Invitations", type: :request do
     end
 
     it "role=1 を指定すると管理者向け招待を発行して返す" do
+      cookies[:staff_id] = "1"
       get "/api/admin/invitation/issue?role=1"
       expect(response).to have_http_status(200)
       body = JSON.parse(response.body)
@@ -46,6 +53,7 @@ RSpec.describe "Admin::Invitations", type: :request do
     end
 
     it "role が不正なら 400 を返す" do
+      cookies[:staff_id] = "1"
       get "/api/admin/invitation/issue?role=0"
       expect(response).to have_http_status(400)
     end

--- a/backends/ruby-rails/spec/requests/admin/invitations_spec.rb
+++ b/backends/ruby-rails/spec/requests/admin/invitations_spec.rb
@@ -4,23 +4,50 @@ require "rails_helper"
 
 RSpec.describe "Admin::Invitations", type: :request do
   describe "GET /api/admin/invitation" do
-    it "現在の招待情報を返す" do
-      inv = create_invitation
+    it "現在の招待情報を返す（デフォルト role=2）" do
+      inv = create_invitation(SecureRandom.hex(16), 2)
       get "/api/admin/invitation"
       expect(response).to have_http_status(200)
       body = JSON.parse(response.body)
       expect(body["found"]).to be true
       expect(body["token"]).to eq(inv.token)
     end
+
+    it "role=1 を指定すると管理者向け招待情報を返す" do
+      inv = create_invitation(SecureRandom.hex(16), 1)
+      get "/api/admin/invitation?role=1"
+      expect(response).to have_http_status(200)
+      body = JSON.parse(response.body)
+      expect(body["found"]).to be true
+      expect(body["token"]).to eq(inv.token)
+    end
+
+    it "role が不正なら 400 を返す" do
+      get "/api/admin/invitation?role=3"
+      expect(response).to have_http_status(400)
+    end
   end
 
   describe "GET /api/admin/invitation/issue" do
-    it "新しい招待を発行して返す" do
+    it "新しい招待を発行して返す（デフォルト role=2）" do
       get "/api/admin/invitation/issue"
       expect(response).to have_http_status(200)
       body = JSON.parse(response.body)
       expect(body["found"]).to be true
       expect(body["token"]).not_to be_nil
+    end
+
+    it "role=1 を指定すると管理者向け招待を発行して返す" do
+      get "/api/admin/invitation/issue?role=1"
+      expect(response).to have_http_status(200)
+      body = JSON.parse(response.body)
+      expect(body["found"]).to be true
+      expect(body["token"]).not_to be_nil
+    end
+
+    it "role が不正なら 400 を返す" do
+      get "/api/admin/invitation/issue?role=0"
+      expect(response).to have_http_status(400)
     end
   end
 end

--- a/backends/ruby-rails/spec/usecase/auth/interactor_spec.rb
+++ b/backends/ruby-rails/spec/usecase/auth/interactor_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe UseCase::Auth::Interactor do
   end
 
   let(:stub_auth_repo) do
-    double("InvitationAuthRepo", find: "tok", remove: nil)
+    double("InvitationAuthRepo", find: Domain::Staff::Role::MEMBER, remove: nil)
   end
 
   describe "#find_user" do

--- a/backends/ruby-rails/spec/usecase/invitation/interactor_spec.rb
+++ b/backends/ruby-rails/spec/usecase/invitation/interactor_spec.rb
@@ -3,21 +3,32 @@
 require "rails_helper"
 
 RSpec.describe UseCase::Invitation::Interactor do
+  let(:make_entity) do
+    ->(token = "tok123", role = 2) {
+      Domain::Invitation::Entity.new(
+        id:    1,
+        token: token,
+        role:  role,
+      )
+    }
+  end
+
   let(:make_vo) do
     ->(token = "tok123") {
       Domain::Invitation::Vo.new(
         token:       token,
-        url:         "http://localhost:3000/register?token=#{token}",
-        display_url: "http://localhost:3000/register?token=#{token}",
+        url:         "http://localhost:3000/invitation/#{token}",
+        display_url: "http://localhost:3000/invitation/#{token}",
       )
     }
   end
 
   let(:stub_repo) do
     double("InvitationRepo",
-      get_current:    make_vo.call,
-      issue:          make_vo.call("new-token"),
-      find_by_token:  nil,
+      get_current_by_role: make_entity.call,
+      issue:               make_entity.call("new-token"),
+      find_by_token:       nil,
+      entity_to_vo:        make_vo.call,
     )
   end
 
@@ -27,27 +38,30 @@ RSpec.describe UseCase::Invitation::Interactor do
 
   describe "#current" do
     it "returns current invitation from repo" do
-      vo = described_class.new(stub_repo, stub_auth_repo).current
+      allow(stub_repo).to receive(:entity_to_vo).and_return(make_vo.call("tok123"))
+      vo = described_class.new(stub_repo, stub_auth_repo).current(2)
       expect(vo.token).to eq "tok123"
     end
 
     it "returns nil when no invitation" do
-      allow(stub_repo).to receive(:get_current).and_return(nil)
-      expect(described_class.new(stub_repo, stub_auth_repo).current).to be_nil
+      allow(stub_repo).to receive(:get_current_by_role).and_return(nil)
+      expect(described_class.new(stub_repo, stub_auth_repo).current(2)).to be_nil
     end
   end
 
   describe "#issue" do
     it "returns newly issued invitation" do
-      vo = described_class.new(stub_repo, stub_auth_repo).issue
+      allow(stub_repo).to receive(:entity_to_vo).and_return(make_vo.call("new-token"))
+      vo = described_class.new(stub_repo, stub_auth_repo).issue(2)
       expect(vo.token).to eq "new-token"
     end
   end
 
   describe "#find_by_token" do
     it "returns vo when token found" do
-      vo = make_vo.call("abc")
-      allow(stub_repo).to receive(:find_by_token).with("abc").and_return(vo)
+      entity = make_entity.call("abc", 1)
+      allow(stub_repo).to receive(:find_by_token).with("abc").and_return(entity)
+      allow(stub_repo).to receive(:entity_to_vo).and_return(make_vo.call("abc"))
       result = described_class.new(stub_repo, stub_auth_repo).find_by_token(UseCase::Invitation::FindByTokenDto.new(token: "abc"))
       expect(result.token).to eq "abc"
     end

--- a/backends/ruby-rails/spec/usecase/invitation/interactor_spec.rb
+++ b/backends/ruby-rails/spec/usecase/invitation/interactor_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe UseCase::Invitation::Interactor do
       entity = make_entity.call("abc", 1)
       allow(stub_repo).to receive(:find_by_token).with("abc").and_return(entity)
       allow(stub_repo).to receive(:entity_to_vo).and_return(make_vo.call("abc"))
+      expect(stub_auth_repo).to receive(:store).with("abc", 1, 600)
       result = described_class.new(stub_repo, stub_auth_repo).find_by_token(UseCase::Invitation::FindByTokenDto.new(token: "abc"))
       expect(result.token).to eq "abc"
     end

--- a/backends/rust-axum/src/domain/invitation/auth_repository.rs
+++ b/backends/rust-axum/src/domain/invitation/auth_repository.rs
@@ -10,10 +10,10 @@ pub type DomainError = Box<dyn std::error::Error + Send + Sync>;
 /// 招待認証トークンのキャッシュリポジトリインターフェース。
 #[async_trait]
 pub trait AuthRepository: Send + Sync {
-    /// トークンを指定秒数キャッシュします。
-    async fn store(&self, token: &str, ttl: u64) -> Result<(), DomainError>;
-    /// トークンを取得します。存在しない場合は None を返します。
-    async fn find(&self, token: &str) -> Result<Option<String>, DomainError>;
+    /// トークンとロールを指定秒数キャッシュします。
+    async fn store(&self, token: &str, role: u8, ttl: u64) -> Result<(), DomainError>;
+    /// トークンに紐づくロールを取得します。存在しない場合は None を返します。
+    async fn find(&self, token: &str) -> Result<Option<u8>, DomainError>;
     /// トークンを削除します。
     async fn remove(&self, token: &str) -> Result<(), DomainError>;
 }

--- a/backends/rust-axum/src/domain/invitation/entity.rs
+++ b/backends/rust-axum/src/domain/invitation/entity.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 pub struct Invitation {
     pub id:         u32,
     pub token:      String,
+    pub role:       u8,
     pub created_at: DateTime<Utc>,
     pub created_by: Option<u32>,
     pub updated_at: DateTime<Utc>,

--- a/backends/rust-axum/src/domain/invitation/repository.rs
+++ b/backends/rust-axum/src/domain/invitation/repository.rs
@@ -11,10 +11,10 @@ pub type DomainError = Box<dyn std::error::Error + Send + Sync>;
 /// 招待のリポジトリインターフェース。
 #[async_trait]
 pub trait Repository: Send + Sync {
-    /// 有効な招待トークンの VO を返します。存在しない場合は None を返します。
-    async fn get_current(&self) -> Result<Option<Vo>, DomainError>;
-    /// 新しい招待トークンを発行して VO を返します。
-    async fn issue(&self) -> Result<Vo, DomainError>;
+    /// ロールに紐づく有効な招待トークンの VO を返します。存在しない場合は None を返します。
+    async fn get_current_by_role(&self, role: u8) -> Result<Option<Vo>, DomainError>;
+    /// ロールを指定して新しい招待トークンを発行して VO を返します。
+    async fn issue(&self, role: u8) -> Result<Vo, DomainError>;
     /// トークン文字列で招待 VO を返します。存在しない場合は None を返します。
     async fn find_by_token(&self, token: &str) -> Result<Option<Vo>, DomainError>;
 }

--- a/backends/rust-axum/src/domain/invitation/value_objects.rs
+++ b/backends/rust-axum/src/domain/invitation/value_objects.rs
@@ -6,6 +6,7 @@
 /// 招待トークン取得・発行結果の VO。
 pub struct Vo {
     pub token:       String,
+    pub role:        u8,
     pub url:         String,
     pub display_url: String,
 }

--- a/backends/rust-axum/src/handler/admin_invitation.rs
+++ b/backends/rust-axum/src/handler/admin_invitation.rs
@@ -3,14 +3,42 @@
 //! # Author
 //! Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{extract::{Query, State}, http::StatusCode, Json};
+use axum_extra::extract::CookieJar;
+use serde::Deserialize;
 use serde_json::{json, Value};
 
-use crate::state::AppState;
+use crate::{
+    state::AppState,
+    usecase::invitation::dto::RoleDto,
+};
+use super::staff_id_from_cookie;
+
+#[derive(Deserialize)]
+pub struct InvitationQuery {
+    role: Option<u8>,
+}
+
+/// クエリパラメーターから role を解決します（1 or 2、それ以外は Err）。
+fn resolve_role(query: &InvitationQuery) -> Result<u8, ()> {
+    let role = query.role.unwrap_or(2);
+    if role == 1 || role == 2 {
+        Ok(role)
+    } else {
+        Err(())
+    }
+}
 
 /// 現在の招待トークン情報を返します。
-pub async fn index(State(state): State<AppState>) -> (StatusCode, Json<Value>) {
-    match state.invitation_uc.current().await {
+pub async fn index(
+    State(state): State<AppState>,
+    Query(query): Query<InvitationQuery>,
+) -> (StatusCode, Json<Value>) {
+    let role = match resolve_role(&query) {
+        Ok(r)  => r,
+        Err(()) => return (StatusCode::BAD_REQUEST, Json(json!({"error": "invalid_role"}))),
+    };
+    match state.invitation_uc.current(RoleDto { role }).await {
         Ok(v) => (StatusCode::OK, Json(json!({
             "found":       true,
             "url":         v.url,
@@ -22,13 +50,27 @@ pub async fn index(State(state): State<AppState>) -> (StatusCode, Json<Value>) {
 }
 
 /// 新しい招待トークンを発行します。トランザクション内で処理します。
-pub async fn issue(State(state): State<AppState>) -> (StatusCode, Json<Value>) {
+pub async fn issue(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Query(query): Query<InvitationQuery>,
+) -> (StatusCode, Json<Value>) {
+    let staff_id = staff_id_from_cookie(&jar);
+    if staff_id == 0 {
+        return (StatusCode::UNAUTHORIZED, Json(json!({"error": "unauthenticated"})));
+    }
+
+    let role = match resolve_role(&query) {
+        Ok(r)  => r,
+        Err(()) => return (StatusCode::BAD_REQUEST, Json(json!({"error": "invalid_role"}))),
+    };
+
     let tx = match state.pool.begin().await {
         Ok(tx) => tx,
         Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "internal_error"}))),
     };
 
-    let result = match state.invitation_uc.issue().await {
+    let result = match state.invitation_uc.issue(RoleDto { role }).await {
         Ok(v) => v,
         Err(_) => {
             let _ = tx.rollback().await;

--- a/backends/rust-axum/src/infrastructure/cache/mod.rs
+++ b/backends/rust-axum/src/infrastructure/cache/mod.rs
@@ -64,18 +64,18 @@ impl RedisInvitationAuthRepository {
 
 #[async_trait]
 impl AuthRepository for RedisInvitationAuthRepository {
-    async fn store(&self, token: &str, ttl: u64) -> Result<(), DomainError> {
+    async fn store(&self, token: &str, role: u8, ttl: u64) -> Result<(), DomainError> {
         let key = self.cache_key(token);
         let mut conn = self.client.get_multiplexed_async_connection().await?;
-        let _: () = conn.set_ex(&key, token, ttl).await?;
+        let _: () = conn.set_ex(&key, role.to_string(), ttl).await?;
         Ok(())
     }
 
-    async fn find(&self, token: &str) -> Result<Option<String>, DomainError> {
+    async fn find(&self, token: &str) -> Result<Option<u8>, DomainError> {
         let key = self.cache_key(token);
         let mut conn = self.client.get_multiplexed_async_connection().await?;
         let val: Option<String> = conn.get(&key).await?;
-        Ok(val)
+        Ok(val.and_then(|s| s.parse::<u8>().ok()))
     }
 
     async fn remove(&self, token: &str) -> Result<(), DomainError> {

--- a/backends/rust-axum/src/infrastructure/persistence/invitation.rs
+++ b/backends/rust-axum/src/infrastructure/persistence/invitation.rs
@@ -16,6 +16,7 @@ struct InvitationRow {
     #[allow(dead_code)]
     id:         u32,
     token:      String,
+    role:       u8,
     #[allow(dead_code)]
     created_at: DateTime<Utc>,
     #[allow(dead_code)]
@@ -44,36 +45,38 @@ impl SqlxInvitationRepository {
         Self { pool, frontend_url }
     }
 
-    fn build_vo(&self, token: &str) -> Vo {
+    fn build_vo(&self, token: &str, role: u8) -> Vo {
         let url         = format!("{}/invitation/{}", self.frontend_url, token);
         let display_url = build_display_url(&url);
-        Vo { token: token.to_string(), url, display_url }
+        Vo { token: token.to_string(), role, url, display_url }
     }
 }
 
 #[async_trait]
 impl Repository for SqlxInvitationRepository {
-    async fn get_current(&self) -> Result<Option<Vo>, DomainError> {
+    async fn get_current_by_role(&self, role: u8) -> Result<Option<Vo>, DomainError> {
         let row = sqlx::query_as::<_, InvitationRow>(
-            "SELECT * FROM invitations ORDER BY id DESC LIMIT 1"
+            "SELECT * FROM invitations WHERE role = ? ORDER BY id DESC LIMIT 1"
         )
+        .bind(role)
         .fetch_optional(&self.pool)
         .await?;
-        Ok(row.map(|r| self.build_vo(&r.token)))
+        Ok(row.map(|r| self.build_vo(&r.token, r.role)))
     }
 
-    async fn issue(&self) -> Result<Vo, DomainError> {
+    async fn issue(&self, role: u8) -> Result<Vo, DomainError> {
         let token = generate_token();
         let now = chrono::Utc::now();
         sqlx::query(
-            "INSERT INTO invitations (token, created_at, created_by, updated_at, updated_by, version) VALUES (?, ?, 0, ?, 0, 1)"
+            "INSERT INTO invitations (token, role, created_at, created_by, updated_at, updated_by, version) VALUES (?, ?, ?, 0, ?, 0, 1)"
         )
         .bind(&token)
+        .bind(role)
         .bind(now)
         .bind(now)
         .execute(&self.pool)
         .await?;
-        Ok(self.build_vo(&token))
+        Ok(self.build_vo(&token, role))
     }
 
     async fn find_by_token(&self, token: &str) -> Result<Option<Vo>, DomainError> {
@@ -83,7 +86,7 @@ impl Repository for SqlxInvitationRepository {
         .bind(token)
         .fetch_optional(&self.pool)
         .await?;
-        Ok(row.map(|r| self.build_vo(&r.token)))
+        Ok(row.map(|r| self.build_vo(&r.token, r.role)))
     }
 }
 

--- a/backends/rust-axum/src/usecase/auth/interactor.rs
+++ b/backends/rust-axum/src/usecase/auth/interactor.rs
@@ -6,7 +6,6 @@
 use std::sync::Arc;
 use crate::domain::staff::{
     entity::Staff,
-    enums::ROLE_MEMBER,
     repository::Repository,
     value_objects::Vo,
 };
@@ -46,9 +45,15 @@ impl Interactor {
             self.staff_repo.save(s).await?
         } else {
             let token = dto.invitation_token.as_deref().unwrap_or("");
-            if token.is_empty() || self.invitation_auth_repo.find(token).await?.is_none() {
-                return Err("invitation_required".to_string().into());
-            }
+            let cached_role = if token.is_empty() {
+                None
+            } else {
+                self.invitation_auth_repo.find(token).await?
+            };
+            let role = match cached_role {
+                Some(r) => r as i32,
+                None    => return Err("invitation_required".to_string().into()),
+            };
             self.invitation_auth_repo.remove(token).await?;
             let new_staff = Staff {
                 id:            0,
@@ -57,7 +62,7 @@ impl Interactor {
                 provider:      dto.provider,
                 provider_id:   dto.provider_id,
                 avatar:        dto.avatar,
-                role:          ROLE_MEMBER,
+                role,
                 last_login_at: Some(now),
                 created_at:    now,
                 created_by:    Some(0),
@@ -112,17 +117,17 @@ mod tests {
     }
 
     struct MockInvitationAuthRepo {
-        stored: Mutex<Option<String>>,
+        stored: Mutex<Option<u8>>,
     }
     impl MockInvitationAuthRepo {
-        fn with_token(token: &str) -> Self { Self { stored: Mutex::new(Some(token.to_string())) } }
+        fn with_role(role: u8) -> Self { Self { stored: Mutex::new(Some(role)) } }
         fn empty() -> Self { Self { stored: Mutex::new(None) } }
     }
     #[async_trait]
     impl InvAuthRepo for MockInvitationAuthRepo {
-        async fn store(&self, _: &str, _: u64) -> Result<(), DomainError> { Ok(()) }
-        async fn find(&self, _: &str) -> Result<Option<String>, DomainError> {
-            Ok(self.stored.lock().unwrap().clone())
+        async fn store(&self, _: &str, _: u8, _: u64) -> Result<(), DomainError> { Ok(()) }
+        async fn find(&self, _: &str) -> Result<Option<u8>, DomainError> {
+            Ok(*self.stored.lock().unwrap())
         }
         async fn remove(&self, _: &str) -> Result<(), DomainError> { Ok(()) }
     }
@@ -193,7 +198,7 @@ mod tests {
     async fn test_login_creates_new_staff_with_invitation() {
         let mock = Arc::new(MockStaffRepo::new());
         *mock.find_by_provider.lock().unwrap() = Some(None);
-        let uc = make_uc(mock, Arc::new(MockInvitationAuthRepo::with_token("tok")));
+        let uc = make_uc(mock, Arc::new(MockInvitationAuthRepo::with_role(2)));
         let dto = LoginDto {
             provider:         1,
             provider_id:      "new_id".to_string(),

--- a/backends/rust-axum/src/usecase/invitation/dto.rs
+++ b/backends/rust-axum/src/usecase/invitation/dto.rs
@@ -7,3 +7,8 @@
 pub struct FindByTokenDto {
     pub token: String,
 }
+
+/// 招待 current/issue 入力 DTO。
+pub struct RoleDto {
+    pub role: u8,
+}

--- a/backends/rust-axum/src/usecase/invitation/interactor.rs
+++ b/backends/rust-axum/src/usecase/invitation/interactor.rs
@@ -9,7 +9,7 @@ use crate::domain::invitation::{
     repository::Repository,
     auth_repository::AuthRepository,
 };
-use super::dto::FindByTokenDto;
+use super::dto::{FindByTokenDto, RoleDto};
 
 pub type UseCaseError = Box<dyn std::error::Error + Send + Sync>;
 
@@ -25,22 +25,22 @@ impl Interactor {
         Self { repo, auth_repo }
     }
 
-    /// 現在有効な招待トークンの VO を返します。存在しない場合はエラーを返します。
-    pub async fn current(&self) -> Result<Vo, UseCaseError> {
-        self.repo.get_current().await?
+    /// ロールに紐づく現在有効な招待トークンの VO を返します。存在しない場合はエラーを返します。
+    pub async fn current(&self, dto: RoleDto) -> Result<Vo, UseCaseError> {
+        self.repo.get_current_by_role(dto.role).await?
             .ok_or_else(|| -> UseCaseError { "invitation_not_found".to_string().into() })
     }
 
-    /// 新しい招待トークンを発行して VO を返します。
-    pub async fn issue(&self) -> Result<Vo, UseCaseError> {
-        Ok(self.repo.issue().await?)
+    /// ロールを指定して新しい招待トークンを発行して VO を返します。
+    pub async fn issue(&self, dto: RoleDto) -> Result<Vo, UseCaseError> {
+        Ok(self.repo.issue(dto.role).await?)
     }
 
     /// トークン文字列で招待 VO を返します。無効な場合はエラーを返します。
     pub async fn find_by_token(&self, dto: FindByTokenDto) -> Result<Vo, UseCaseError> {
         let vo = self.repo.find_by_token(&dto.token).await?
             .ok_or_else(|| -> UseCaseError { "invitation_not_found".to_string().into() })?;
-        self.auth_repo.store(&vo.token, 600).await?;
+        self.auth_repo.store(&vo.token, vo.role, 600).await?;
         Ok(vo)
     }
 }
@@ -75,14 +75,15 @@ mod tests {
 
     #[async_trait]
     impl AuthRepository for MockAuthRepo {
-        async fn store(&self, _: &str, _: u64) -> Result<(), DomainError> { Ok(()) }
-        async fn find(&self, _: &str) -> Result<Option<String>, DomainError> { Ok(None) }
+        async fn store(&self, _: &str, _: u8, _: u64) -> Result<(), DomainError> { Ok(()) }
+        async fn find(&self, _: &str) -> Result<Option<u8>, DomainError> { Ok(None) }
         async fn remove(&self, _: &str) -> Result<(), DomainError> { Ok(()) }
     }
 
     fn make_vo() -> Vo {
         Vo {
             token:       "abc123".to_string(),
+            role:        2,
             url:         "http://localhost:3000/register?token=abc123".to_string(),
             display_url: "http://localhost...token=abc123".to_string(),
         }
@@ -90,10 +91,10 @@ mod tests {
 
     #[async_trait]
     impl Repository for MockRepo {
-        async fn get_current(&self) -> Result<Option<Vo>, DomainError> {
+        async fn get_current_by_role(&self, _: u8) -> Result<Option<Vo>, DomainError> {
             Ok(self.current.lock().unwrap().take().unwrap_or(None))
         }
-        async fn issue(&self) -> Result<Vo, DomainError> {
+        async fn issue(&self, _: u8) -> Result<Vo, DomainError> {
             Ok(self.issue.lock().unwrap().take().unwrap_or_else(make_vo))
         }
         async fn find_by_token(&self, _: &str) -> Result<Option<Vo>, DomainError> {
@@ -110,7 +111,7 @@ mod tests {
         let mock = Arc::new(MockRepo::new());
         *mock.current.lock().unwrap() = Some(Some(make_vo()));
         let uc = make_uc(mock);
-        let vo = uc.current().await.unwrap();
+        let vo = uc.current(RoleDto { role: 2 }).await.unwrap();
         assert_eq!(vo.token, "abc123");
     }
 
@@ -119,7 +120,7 @@ mod tests {
         let mock = Arc::new(MockRepo::new());
         *mock.current.lock().unwrap() = Some(None);
         let uc = make_uc(mock);
-        assert!(uc.current().await.is_err());
+        assert!(uc.current(RoleDto { role: 2 }).await.is_err());
     }
 
     #[tokio::test]
@@ -127,7 +128,7 @@ mod tests {
         let mock = Arc::new(MockRepo::new());
         *mock.issue.lock().unwrap() = Some(make_vo());
         let uc = make_uc(mock);
-        let vo = uc.issue().await.unwrap();
+        let vo = uc.issue(RoleDto { role: 2 }).await.unwrap();
         assert!(!vo.token.is_empty());
         assert!(vo.url.contains(&vo.token));
     }

--- a/backends/rust-axum/tests/common/mod.rs
+++ b/backends/rust-axum/tests/common/mod.rs
@@ -84,6 +84,7 @@ async fn ensure_schema(pool: &MySqlPool) {
         "CREATE TABLE `invitations` (
             `id`            INT UNSIGNED    NOT NULL AUTO_INCREMENT,
             `token`         VARCHAR(255)    NOT NULL,
+            `role`          TINYINT UNSIGNED NOT NULL DEFAULT 2,
             `created_at`    DATETIME        NOT NULL,
             `created_by`    INT UNSIGNED,
             `updated_at`    DATETIME        NOT NULL,
@@ -206,11 +207,12 @@ pub async fn create_client(pool: &MySqlPool) -> ClientData {
     }
 }
 
-pub async fn create_invitation(pool: &MySqlPool) -> String {
+pub async fn create_invitation(pool: &MySqlPool, role: u8) -> String {
     let token = hex::encode(rand::random::<[u8; 16]>());
     let now = chrono::Local::now().naive_local();
-    sqlx::query("INSERT INTO invitations (token, created_at, updated_at) VALUES (?, ?, ?)")
+    sqlx::query("INSERT INTO invitations (token, role, created_at, updated_at) VALUES (?, ?, ?, ?)")
         .bind(&token)
+        .bind(role)
         .bind(now)
         .bind(now)
         .execute(pool)

--- a/backends/rust-axum/tests/integration.rs
+++ b/backends/rust-axum/tests/integration.rs
@@ -208,10 +208,10 @@ async fn delete_staffs_destroy_soft_deletes_staff() {
 async fn get_admin_invitation_returns_existing_invitation() {
     let (app, pool) = common::build_test_app().await;
     common::truncate_tables(&pool).await;
-    let token = common::create_invitation(&pool).await;
+    let token = common::create_invitation(&pool, 2).await;
 
     let req = Request::builder()
-        .uri("/api/admin/invitation")
+        .uri("/api/admin/invitation?role=2")
         .body(axum::body::Body::empty())
         .unwrap();
 
@@ -225,12 +225,62 @@ async fn get_admin_invitation_returns_existing_invitation() {
 }
 
 #[tokio::test]
-async fn get_admin_invitation_issue_creates_new_invitation() {
+async fn get_admin_invitation_returns_existing_admin_invitation() {
+    let (app, pool) = common::build_test_app().await;
+    common::truncate_tables(&pool).await;
+    let token = common::create_invitation(&pool, 1).await;
+
+    let req = Request::builder()
+        .uri("/api/admin/invitation?role=1")
+        .body(axum::body::Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["found"], true);
+    assert_eq!(json["token"], token);
+}
+
+#[tokio::test]
+async fn get_admin_invitation_returns_400_for_invalid_role() {
     let (app, pool) = common::build_test_app().await;
     common::truncate_tables(&pool).await;
 
     let req = Request::builder()
-        .uri("/api/admin/invitation/issue")
+        .uri("/api/admin/invitation?role=3")
+        .body(axum::body::Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn get_admin_invitation_issue_requires_auth() {
+    let (app, pool) = common::build_test_app().await;
+    common::truncate_tables(&pool).await;
+
+    let req = Request::builder()
+        .uri("/api/admin/invitation/issue?role=2")
+        .body(axum::body::Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn get_admin_invitation_issue_creates_new_invitation() {
+    let (app, pool) = common::build_test_app().await;
+    common::truncate_tables(&pool).await;
+    let staff_id = common::create_staff(&pool).await;
+
+    let req = Request::builder()
+        .uri("/api/admin/invitation/issue?role=2")
+        .header(axum::http::header::COOKIE, format!("staff_id={}", staff_id))
         .body(axum::body::Body::empty())
         .unwrap();
 

--- a/backends/ts-hono/src/db/schema.ts
+++ b/backends/ts-hono/src/db/schema.ts
@@ -42,6 +42,7 @@ export const staffs = mysqlTable("staffs", {
 export const invitations = mysqlTable("invitations", {
   id: bigint("id", { mode: "number", unsigned: true }).primaryKey().autoincrement(),
   token: varchar("token", { length: 255 }).notNull(),
+  role: int("role").notNull().default(2),
   createdAt: datetime("created_at").default(sql`CURRENT_TIMESTAMP`),
   updatedAt: datetime("updated_at").default(sql`CURRENT_TIMESTAMP`),
 });

--- a/backends/ts-hono/src/domain/invitation/authRepository.ts
+++ b/backends/ts-hono/src/domain/invitation/authRepository.ts
@@ -6,10 +6,10 @@
 
 /** 招待認証トークンのキャッシュリポジトリインターフェース。 */
 export interface InvitationAuthRepository {
-  /** トークンを指定秒数キャッシュします。 */
-  store(token: string, ttl: number): Promise<void>;
-  /** トークンを取得します。存在しない場合は null を返します。 */
-  find(token: string): Promise<string | null>;
+  /** トークンとロールを指定秒数キャッシュします。 */
+  store(token: string, role: number, ttl: number): Promise<void>;
+  /** トークンに紐づくロールを取得します。存在しない場合は null を返します。 */
+  find(token: string): Promise<number | null>;
   /** トークンを削除します。 */
   remove(token: string): Promise<void>;
 }

--- a/backends/ts-hono/src/domain/invitation/entity.ts
+++ b/backends/ts-hono/src/domain/invitation/entity.ts
@@ -8,6 +8,7 @@
 export interface Invitation {
   id: number;
   token: string;
+  role: number;
   createdAt: Date | null;
   updatedAt: Date | null;
 }

--- a/backends/ts-hono/src/domain/invitation/repository.ts
+++ b/backends/ts-hono/src/domain/invitation/repository.ts
@@ -8,6 +8,7 @@ import type { Invitation } from "./entity.js";
 /** 招待のリポジトリインターフェース。 */
 export interface InvitationRepository {
   getCurrent(): Promise<Invitation | undefined>;
-  issue(token: string): Promise<Invitation>;
+  getCurrentByRole(role: number): Promise<Invitation | undefined>;
+  issue(token: string, role: number): Promise<Invitation>;
   findByToken(token: string): Promise<Invitation | undefined>;
 }

--- a/backends/ts-hono/src/infrastructure/cache/redisInvitationAuthRepository.ts
+++ b/backends/ts-hono/src/infrastructure/cache/redisInvitationAuthRepository.ts
@@ -20,8 +20,9 @@ export class RedisInvitationAuthRepository implements InvitationAuthRepository {
   async find(token: string): Promise<number | null> {
     const val = await redis.get(cacheKey(token));
     if (val === null) return null;
-    const n = parseInt(val, 10);
-    return isNaN(n) ? null : n;
+    const n = Number(val);
+    if (!Number.isInteger(n)) return null;
+    return n === 1 || n === 2 ? n : null;
   }
 
   async remove(token: string): Promise<void> {

--- a/backends/ts-hono/src/infrastructure/cache/redisInvitationAuthRepository.ts
+++ b/backends/ts-hono/src/infrastructure/cache/redisInvitationAuthRepository.ts
@@ -13,12 +13,15 @@ function cacheKey(token: string): string {
 
 /** Redis を用いた招待認証キャッシュリポジトリ。 */
 export class RedisInvitationAuthRepository implements InvitationAuthRepository {
-  async store(token: string, ttl: number): Promise<void> {
-    await redis.setex(cacheKey(token), ttl, token);
+  async store(token: string, role: number, ttl: number): Promise<void> {
+    await redis.setex(cacheKey(token), ttl, String(role));
   }
 
-  async find(token: string): Promise<string | null> {
-    return redis.get(cacheKey(token));
+  async find(token: string): Promise<number | null> {
+    const val = await redis.get(cacheKey(token));
+    if (val === null) return null;
+    const n = parseInt(val, 10);
+    return isNaN(n) ? null : n;
   }
 
   async remove(token: string): Promise<void> {

--- a/backends/ts-hono/src/infrastructure/model/schema.ts
+++ b/backends/ts-hono/src/infrastructure/model/schema.ts
@@ -55,6 +55,7 @@ export const staffs = mysqlTable("staffs", {
 export const invitations = mysqlTable("invitations", {
   id: bigint("id", { mode: "number", unsigned: true }).primaryKey().autoincrement(),
   token: varchar("token", { length: 255 }).notNull(),
+  role: int("role", { unsigned: true }).notNull().default(2),
   createdAt: datetime("created_at").default(sql`CURRENT_TIMESTAMP`),
   createdBy: int("created_by", { unsigned: true }),
   updatedAt: datetime("updated_at").default(sql`CURRENT_TIMESTAMP`),

--- a/backends/ts-hono/src/infrastructure/persistence/drizzleInvitationRepository.ts
+++ b/backends/ts-hono/src/infrastructure/persistence/drizzleInvitationRepository.ts
@@ -17,8 +17,13 @@ export class DrizzleInvitationRepository implements InvitationRepository {
     return all[all.length - 1];
   }
 
-  async issue(token: string): Promise<Invitation> {
-    await this.db.insert(invitations).values({ token, createdBy: 0, updatedBy: 0 });
+  async getCurrentByRole(role: number): Promise<Invitation | undefined> {
+    const all = await this.db.select().from(invitations).where(eq(invitations.role, role)).orderBy(invitations.id);
+    return all[all.length - 1];
+  }
+
+  async issue(token: string, role: number): Promise<Invitation> {
+    await this.db.insert(invitations).values({ token, role, createdBy: 0, updatedBy: 0 });
     const rows = await this.db.select().from(invitations).where(eq(invitations.token, token)).limit(1);
     return rows[0]!;
   }

--- a/backends/ts-hono/src/infrastructure/persistence/drizzleInvitationRepository.ts
+++ b/backends/ts-hono/src/infrastructure/persistence/drizzleInvitationRepository.ts
@@ -3,7 +3,7 @@
  *
  * @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
  */
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { invitations } from "../model/schema.js";
 import type { InvitationRepository } from "../../domain/invitation/repository.js";
 import type { Invitation } from "../../domain/invitation/entity.js";
@@ -13,13 +13,13 @@ export class DrizzleInvitationRepository implements InvitationRepository {
   constructor(private readonly db: DB) {}
 
   async getCurrent(): Promise<Invitation | undefined> {
-    const all = await this.db.select().from(invitations).orderBy(invitations.id);
-    return all[all.length - 1];
+    const rows = await this.db.select().from(invitations).orderBy(desc(invitations.id)).limit(1);
+    return rows[0];
   }
 
   async getCurrentByRole(role: number): Promise<Invitation | undefined> {
-    const all = await this.db.select().from(invitations).where(eq(invitations.role, role)).orderBy(invitations.id);
-    return all[all.length - 1];
+    const rows = await this.db.select().from(invitations).where(eq(invitations.role, role)).orderBy(desc(invitations.id)).limit(1);
+    return rows[0];
   }
 
   async issue(token: string, role: number): Promise<Invitation> {

--- a/backends/ts-hono/src/routes/adminInvitations.ts
+++ b/backends/ts-hono/src/routes/adminInvitations.ts
@@ -8,22 +8,34 @@ import { db, asTx } from "../db/client.js";
 import { DrizzleInvitationRepository } from "../infrastructure/persistence/drizzleInvitationRepository.js";
 import { RedisInvitationAuthRepository } from "../infrastructure/cache/redisInvitationAuthRepository.js";
 import { InvitationInteractor } from "../usecase/invitation/interactor.js";
+import { badRequest, unauthorized } from "../lib/errors.js";
+import { getStaffIdFromCookie } from "../lib/cookie.js";
 
 const invitationAuthRepo = new RedisInvitationAuthRepository();
 
 const app = new Hono();
 
+function parseRole(raw: string | undefined): number {
+  const role = raw !== undefined ? parseInt(raw, 10) : 2;
+  if (role !== 1 && role !== 2) throw badRequest("invalid_role");
+  return role;
+}
+
 app.get("/invitation", async (c) => {
+  const role = parseRole(c.req.query("role"));
   const uc = new InvitationInteractor(new DrizzleInvitationRepository(db), invitationAuthRepo);
-  const result = await uc.current();
+  const result = await uc.current(role);
   return c.json({ found: true, url: result.url, display_url: result.displayUrl, token: result.token });
 });
 
 app.get("/invitation/issue", async (c) => {
+  const staffId = getStaffIdFromCookie(c);
+  if (!staffId) throw unauthorized("unauthenticated");
+  const role = parseRole(c.req.query("role"));
   let result!: Awaited<ReturnType<InvitationInteractor["issue"]>>;
   await db.transaction(async (tx) => {
     const uc = new InvitationInteractor(new DrizzleInvitationRepository(asTx(tx)), invitationAuthRepo);
-    result = await uc.issue();
+    result = await uc.issue(role);
   });
   return c.json({ found: true, url: result.url, display_url: result.displayUrl, token: result.token });
 });

--- a/backends/ts-hono/src/routes/adminInvitations.ts
+++ b/backends/ts-hono/src/routes/adminInvitations.ts
@@ -16,9 +16,9 @@ const invitationAuthRepo = new RedisInvitationAuthRepository();
 const app = new Hono();
 
 function parseRole(raw: string | undefined): number {
-  const role = raw !== undefined ? parseInt(raw, 10) : 2;
-  if (role !== 1 && role !== 2) throw badRequest("invalid_role");
-  return role;
+  if (raw === undefined) return 2;
+  if (raw !== "1" && raw !== "2") throw badRequest("invalid_role");
+  return Number(raw);
 }
 
 app.get("/invitation", async (c) => {

--- a/backends/ts-hono/src/test/adminInvitations.test.ts
+++ b/backends/ts-hono/src/test/adminInvitations.test.ts
@@ -1,32 +1,56 @@
 import { describe, test, expect } from "vitest";
 import { createApp } from "../app.js";
-import { makeInvitation } from "./helpers.js";
+import { makeInvitation, makeStaff } from "./helpers.js";
 
 const app = createApp();
 
 describe("AdminInvitations", () => {
   describe("GET /api/admin/invitation", () => {
     test("現在の招待URLが取得できる", async () => {
-      const inv = await makeInvitation("current-token");
-      const res = await app.request("/api/admin/invitation");
+      const inv = await makeInvitation("current-token", 2);
+      const res = await app.request("/api/admin/invitation?role=2");
       expect(res.status).toBe(200);
       const body = await res.json() as Record<string, unknown>;
       expect(body.token).toBe(inv.token);
     });
+
+    test("roleパラメータが不正な場合は400が返る", async () => {
+      const res = await app.request("/api/admin/invitation?role=3");
+      expect(res.status).toBe(400);
+    });
   });
 
   describe("GET /api/admin/invitation/issue", () => {
-    test("招待URLが発行できる", async () => {
-      const res = await app.request("/api/admin/invitation/issue");
+    test("認証済みで招待URLが発行できる", async () => {
+      const staff = await makeStaff();
+      const res = await app.request("/api/admin/invitation/issue?role=2", {
+        headers: { Cookie: `staff_id=${staff.id}` },
+      });
       expect(res.status).toBe(200);
       const body = await res.json() as Record<string, unknown>;
       expect(body.token).toBeTruthy();
       expect(body.url).toBeTruthy();
     });
 
-    test("再発行で新しいトークンが返る", async () => {
-      await makeInvitation("old-token");
+    test("未認証で401が返る", async () => {
       const res = await app.request("/api/admin/invitation/issue");
+      expect(res.status).toBe(401);
+    });
+
+    test("roleパラメータが不正な場合は400が返る", async () => {
+      const staff = await makeStaff();
+      const res = await app.request("/api/admin/invitation/issue?role=5", {
+        headers: { Cookie: `staff_id=${staff.id}` },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    test("再発行で新しいトークンが返る", async () => {
+      const staff = await makeStaff();
+      await makeInvitation("old-token", 2);
+      const res = await app.request("/api/admin/invitation/issue?role=2", {
+        headers: { Cookie: `staff_id=${staff.id}` },
+      });
       expect(res.status).toBe(200);
       const body = await res.json() as Record<string, unknown>;
       expect(body.token).not.toBe("old-token");

--- a/backends/ts-hono/src/test/helpers.ts
+++ b/backends/ts-hono/src/test/helpers.ts
@@ -38,6 +38,7 @@ export interface TestClient {
 export interface TestInvitation {
   id: number;
   token: string;
+  role: number;
 }
 
 export interface TestNotification {
@@ -86,13 +87,13 @@ export async function makeClientRecord(overrides: Partial<{ identifier: string; 
   return { id: result.insertId, name: data.name, identifier: data.identifier, token, privateKey: privatePem, publicKey: publicPem };
 }
 
-export async function makeInvitation(tokenStr?: string): Promise<TestInvitation> {
+export async function makeInvitation(tokenStr?: string, role = 2): Promise<TestInvitation> {
   const tok = tokenStr ?? randomBytes(16).toString("hex");
   const [result] = await pool.execute(
-    "INSERT INTO invitations (token) VALUES (?)",
-    [tok],
+    "INSERT INTO invitations (token, role) VALUES (?, ?)",
+    [tok, role],
   ) as mysql.ResultSetHeader[];
-  return { id: result.insertId, token: tok };
+  return { id: result.insertId, token: tok, role };
 }
 
 export async function makeNotification(staffId: number, title = "テスト通知", url?: string | null): Promise<TestNotification> {

--- a/backends/ts-hono/src/test/setup.ts
+++ b/backends/ts-hono/src/test/setup.ts
@@ -78,6 +78,7 @@ CREATE TABLE \`clients\` (
 CREATE TABLE \`invitations\` (
   \`id\`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
   \`token\`         VARCHAR(255)    NOT NULL,
+  \`role\`          INT UNSIGNED    NOT NULL DEFAULT 2,
   \`created_at\`    DATETIME        DEFAULT CURRENT_TIMESTAMP,
   \`created_by\`    INT UNSIGNED    NULL,
   \`updated_at\`    DATETIME        DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/backends/ts-hono/src/usecase/auth/interactor.ts
+++ b/backends/ts-hono/src/usecase/auth/interactor.ts
@@ -49,7 +49,8 @@ export class AuthInteractor {
     }
 
     const token = input.invitationToken ?? "";
-    if (!token || !(await this.invitationAuthRepo.find(token))) {
+    const roleValue = token ? await this.invitationAuthRepo.find(token) : null;
+    if (!token || roleValue === null) {
       throw forbidden("invitation_required");
     }
     await this.invitationAuthRepo.remove(token);
@@ -60,7 +61,7 @@ export class AuthInteractor {
       name: input.name,
       email: input.email,
       avatar: input.avatar ?? null,
-      role: 0,
+      role: roleValue,
       lastLoginAt: new Date(),
     });
     return mapper.map(staff, StaffSymbol, StaffVoSymbol);

--- a/backends/ts-hono/src/usecase/auth/interactor.ts
+++ b/backends/ts-hono/src/usecase/auth/interactor.ts
@@ -50,7 +50,7 @@ export class AuthInteractor {
 
     const token = input.invitationToken ?? "";
     const roleValue = token ? await this.invitationAuthRepo.find(token) : null;
-    if (!token || roleValue === null) {
+    if (!token || roleValue === null || (roleValue !== 1 && roleValue !== 2)) {
       throw forbidden("invitation_required");
     }
     await this.invitationAuthRepo.remove(token);

--- a/backends/ts-hono/src/usecase/invitation/interactor.ts
+++ b/backends/ts-hono/src/usecase/invitation/interactor.ts
@@ -24,22 +24,24 @@ export class InvitationInteractor {
 
   /**
    * 最新の招待情報の VO を返します。
+   * @param role - ロール (1=admin, 2=member)
    * @returns InvitationResult
    * @throws AppError 招待が存在しない場合
    */
-  async current(): Promise<InvitationResult> {
-    const inv = await this.repo.getCurrent();
+  async current(role: number): Promise<InvitationResult> {
+    const inv = await this.repo.getCurrentByRole(role);
     if (!inv) throw notFound("invitation_not_found");
     return buildResult(inv.token);
   }
 
   /**
    * 新しい招待トークンを発行し、VO を返します。
+   * @param role - ロール (1=admin, 2=member)
    * @returns InvitationResult
    */
-  async issue(): Promise<InvitationResult> {
+  async issue(role: number): Promise<InvitationResult> {
     const token = randomBytes(16).toString("hex");
-    const inv = await this.repo.issue(token);
+    const inv = await this.repo.issue(token, role);
     return buildResult(inv.token);
   }
 
@@ -52,7 +54,7 @@ export class InvitationInteractor {
   async findByToken(token: string): Promise<InvitationResult> {
     const inv = await this.repo.findByToken(token);
     if (!inv) throw notFound("invitation_not_found");
-    await this.authRepo.store(inv.token, 600);
+    await this.authRepo.store(inv.token, inv.role, 600);
     return buildResult(inv.token);
   }
 }

--- a/docs/api-spec/openapi.yml
+++ b/docs/api-spec/openapi.yml
@@ -838,6 +838,16 @@ paths:
       tags:
         - admin
       security: []
+      parameters:
+        - name: role
+          in: query
+          required: false
+          description: 招待するスタッフの権限（1=管理者, 2=メンバー）。省略時は 2（メンバー）。
+          schema:
+            type: integer
+            enum: [1, 2]
+            default: 2
+          example: 2
       responses:
         '200':
           description: 成功時にレスポンスを返します。
@@ -850,6 +860,8 @@ paths:
                     type: string
                     description: 招待用トークン（ハッシュ）を含むURL
                     example: "/auth/invitation/7f3a9c2e1b8d4f6a0e5c7b2d9f1a4e8c0d3b6a9f2e5c8d1b4a7f0e3c6d9b2a5f8"
+        '400':
+          description: role パラメーターが不正
         '401':
           description: 未認証
         '500':

--- a/frontend/components/invitation-url-modal.tsx
+++ b/frontend/components/invitation-url-modal.tsx
@@ -3,53 +3,35 @@ import { AnimatePresence, motion } from "framer-motion";
 import { ClipboardCopy, X, Loader2 } from "lucide-react";
 import { getInvitation, issueInvitation } from "@/src/api";
 
-/** API 未実装・500・CORS 等のときに見せる、それっぽいモックURL */
-function buildMockInvitationUrl(): string {
-  const bytes = new Uint8Array(24);
-  crypto.getRandomValues(bytes);
-  const token = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-  const origin = typeof window !== "undefined" ? window.location.origin : "";
-  return `${origin}/invitation/${token}`;
-}
-
 type Props = {
   open: boolean;
   onClose: () => void;
 };
 
 export function InvitationUrlModal({ open, onClose }: Props): React.JSX.Element {
+  const [role, setRole] = useState<1 | 2>(2);
   const [url, setUrl] = useState<string>("");
   const [displayUrl, setDisplayUrl] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(false);
   const [reissuing, setReissuing] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<boolean>(false);
-  const [isMock, setIsMock] = useState<boolean>(false);
-
-  const setUrls = (fullUrl: string, dispUrl: string) => {
-    setUrl(fullUrl);
-    setDisplayUrl(dispUrl);
-  };
 
   const loadUrl = useCallback(async () => {
     setError(null);
+    setUrl("");
+    setDisplayUrl("");
     setLoading(true);
     try {
-      const data = await getInvitation();
-      const mockUrl = buildMockInvitationUrl();
-      setUrls(
-        typeof data.url === "string" ? data.url : mockUrl,
-        typeof data.display_url === "string" ? data.display_url : mockUrl,
-      );
-      setIsMock(false);
+      const data = await getInvitation(role);
+      setUrl(data.url);
+      setDisplayUrl(data.display_url);
     } catch {
-      const mockUrl = buildMockInvitationUrl();
-      setUrls(mockUrl, mockUrl);
-      setIsMock(true);
+      setError("招待URLの取得に失敗しました");
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [role]);
 
   useEffect(() => {
     if (!open) return;
@@ -80,17 +62,11 @@ export function InvitationUrlModal({ open, onClose }: Props): React.JSX.Element 
     setError(null);
     setReissuing(true);
     try {
-      const data = await issueInvitation();
-      const mockUrl = buildMockInvitationUrl();
-      setUrls(
-        typeof data.url === "string" ? data.url : mockUrl,
-        typeof data.display_url === "string" ? data.display_url : mockUrl,
-      );
-      setIsMock(false);
+      const data = await issueInvitation(role);
+      setUrl(data.url);
+      setDisplayUrl(data.display_url);
     } catch {
-      const mockUrl = buildMockInvitationUrl();
-      setUrls(mockUrl, mockUrl);
-      setIsMock(true);
+      setError("招待URLの再発行に失敗しました");
     } finally {
       setReissuing(false);
     }
@@ -132,16 +108,41 @@ export function InvitationUrlModal({ open, onClose }: Props): React.JSX.Element 
             </div>
 
             <div className="space-y-4 px-5 py-5">
-              {isMock && (
-                <div className="rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2 text-sm text-indigo-900">
-                  APIが未接続・エラー時のため、モックの招待URLを表示しています（見た目の確認用です）。
-                </div>
-              )}
               {error && (
                 <div className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-800">
                   {error}
                 </div>
               )}
+
+              <div className="space-y-1.5">
+                <p className="text-sm font-medium text-gray-700">権限</p>
+                <div className="flex gap-3">
+                  {([
+                    { value: 2, label: "メンバー", active: "border-sky-200 bg-sky-100 text-sky-800" },
+                    { value: 1, label: "管理者",   active: "border-violet-200 bg-violet-100 text-violet-800" },
+                  ] as const).map(({ value, label, active }) => (
+                    <label
+                      key={value}
+                      className={`flex cursor-pointer items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors ${
+                        role === value
+                          ? active
+                          : "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50"
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="invitation-role"
+                        value={value}
+                        checked={role === value}
+                        onChange={() => setRole(value)}
+                        disabled={loading || reissuing}
+                        className="sr-only"
+                      />
+                      {label}
+                    </label>
+                  ))}
+                </div>
+              </div>
 
               <div className="space-y-2">
                 <label htmlFor="invitation-url-field" className="block text-sm font-medium text-gray-700">

--- a/frontend/src/api/invitation.ts
+++ b/frontend/src/api/invitation.ts
@@ -6,12 +6,12 @@ export type InvitationUrlResponse = {
   token: string;
 };
 
-/** GET /admin/invitation */
-export async function getInvitation(): Promise<InvitationUrlResponse> {
-  return apiGet<InvitationUrlResponse>("/admin/invitation");
+/** GET /admin/invitation?role={role} */
+export async function getInvitation(role: 1 | 2 = 2): Promise<InvitationUrlResponse> {
+  return apiGet<InvitationUrlResponse>(`/admin/invitation?role=${role}`);
 }
 
-/** GET /admin/invitation/issue */
-export async function issueInvitation(): Promise<InvitationUrlResponse> {
-  return apiGet<InvitationUrlResponse>("/admin/invitation/issue");
+/** GET /admin/invitation/issue?role={role} */
+export async function issueInvitation(role: 1 | 2 = 2): Promise<InvitationUrlResponse> {
+  return apiGet<InvitationUrlResponse>(`/admin/invitation/issue?role=${role}`);
 }


### PR DESCRIPTION
## Summary

- 招待URLを権限（1=管理者 / 2=メンバー）ごとに分離
- `GET /admin/invitation?role=` / `GET /admin/invitation/issue?role=` に対応
- 全10バックエンド（PHP / Go×3 / Kotlin / Python / Ruby×2 / Rust / TypeScript）に展開
- フロントエンドのモーダルにロール選択UIを追加し、バックエンドと接続

## Changes

- **openapi.yml**: `/admin/invitation` に `role` クエリパラメーター追加
- **フロントエンド**: ロール選択UI追加、モックを削除してAPIと接続
- **全バックエンド共通**:
  - `invitations.role` カラム追加（INT NOT NULL DEFAULT 2）
  - `InvitationAuthRepository`: `store(token, role, ttl)` / `find(token) → int?`
  - `InvitationRepository`: `getCurrentByRole(role)` でロール別取得
  - `AdminInvitationHandler`: `?role` パラメーター対応（省略=2、1/2以外=400、`issue` は未認証=401）
  - `AuthInteractor.login`: キャッシュの role で `StaffRole` を動的割り当て

## Test plan

- [ ] 各バックエンドのユニット・結合テストが CI でグリーン
- [ ] フロントエンド: メンバー/管理者それぞれの招待URLが取得・再発行できる
- [ ] 無効な role（3等）は 400 を返す
- [ ] 未ログイン状態で issue は 401 を返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 招待コードがロール別（管理者/メンバー）に対応。管理者権限またはメンバー権限を持つユーザーを別途招待できるようになりました。
  * 招待管理画面で権限を選択して招待URLを取得・再発行できるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bobtabo/authorization/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->