### PR TITLE
feat: docker-common.sh に env コマンドを追加

### DIFF
--- a/docker/bin/docker-common.sh
+++ b/docker/bin/docker-common.sh
@@ -19,7 +19,11 @@ elif [ "${ARG}" = "start" ]; then
     docker-compose start
 elif [ "${ARG}" = "stop" ]; then
     docker-compose stop
+elif [ "${ARG}" = "env" ]; then
+    cp ./environment/default.crt ./proxy/certs/default.crt
+    cp ./environment/default.key ./proxy/certs/default.key
+    cp ./environment/.env.example ./.env
 else
-    echo "使い方: $0 {up|down|start|stop}"
+    echo "使い方: $0 {up|down|start|stop|env}"
     exit 1
 fi


### PR DESCRIPTION
## Summary
- `bin/docker-common.sh env` で証明書・.env ファイルをコピーする処理を追加
- 4月6日の「docker操作シェル修正」コミットで削除された `docker-environment.sh` の処理を復元

## Test plan
- [ ] `bin/docker-common.sh env` を実行して3ファイルがコピーされることを確認
- [ ] `bin/docker-common.sh` 引数なしで usage に `env` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* Docker セットアップで新たに `env` コマンドのサポートを追加しました。このコマンド実行時に、証明書ファイルと環境設定ファイルが自動的に配置・初期化されます。あわせて、コマンドの使用方法メッセージも更新されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bobtabo/authorization/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->