### PR TITLE
fix: UI フロー図のログイン成功矢印位置を調整

### DIFF
--- a/docs/ui-flow/src/app/App.tsx
+++ b/docs/ui-flow/src/app/App.tsx
@@ -87,7 +87,7 @@ export default function App() {
               {/* クライアント一覧（TOPページ） */}
               <div className="flex flex-col items-center gap-4 relative">
                 {/* ログイン成功の横矢印 */}
-                <div className="absolute -left-32 top-8 flex items-center gap-2">
+                <div className="absolute -left-20 top-8 flex items-center gap-2">
                   <div className="text-xs font-semibold text-indigo-600">ログイン成功</div>
                   <ArrowRight className="text-indigo-500" size={28} strokeWidth={3} />
                 </div>


### PR DESCRIPTION
## Summary

- ログイン成功の横矢印ブロックを右に全角3文字分（3rem）寄せる
- `-left-32` → `-left-20` に変更

## Test plan

- [ ] UI フロー図（docs/ui-flow）を起動して矢印位置を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)