### PR TITLE
feat: #67 メール刷新・#18 JWT履歴・その他バグ修正

### DIFF
--- a/backends/go-beego/internal/domain/client/value_objects.go
+++ b/backends/go-beego/internal/domain/client/value_objects.go
@@ -33,6 +33,7 @@ type DetailVo struct {
 type StoreVo struct {
 	ID          uint64
 	Name        string
+	Identifier  string
 	Email       string
 	AccessToken string
 }

--- a/backends/go-beego/internal/handler/client_handler.go
+++ b/backends/go-beego/internal/handler/client_handler.go
@@ -24,6 +24,7 @@ type ClientHandler struct {
 	newNotifUC  func(persistence.QueryOrmer) *unotification.Interactor
 	mailer      *mail.Mailer
 	historyRepo domclient.JwtHistoryRepository
+	frontendURL string
 }
 
 func NewClientHandler(
@@ -32,6 +33,7 @@ func NewClientHandler(
 	newNotifUC func(persistence.QueryOrmer) *unotification.Interactor,
 	mailer *mail.Mailer,
 	historyRepo domclient.JwtHistoryRepository,
+	frontendURL string,
 ) *ClientHandler {
 	return &ClientHandler{
 		ormer:       ormer,
@@ -39,6 +41,7 @@ func NewClientHandler(
 		newNotifUC:  newNotifUC,
 		mailer:      mailer,
 		historyRepo: historyRepo,
+		frontendURL: frontendURL,
 	}
 }
 
@@ -128,7 +131,8 @@ func (h *ClientHandler) Store(ctx *beecontext.Context) {
 		URL:         notifURL,
 	})
 
-	go h.mailer.SendAccessToken(storeVo.Email, storeVo.Name, storeVo.AccessToken)
+	activateURL := h.frontendURL + "/clients/" + storeVo.Identifier + "/qr"
+	go h.mailer.SendActivation(storeVo.Email, storeVo.Name, activateURL)
 
 	writeJSON(ctx, http.StatusCreated, map[string]interface{}{"id": storeVo.ID})
 }

--- a/backends/go-beego/internal/infrastructure/mail/mailer.go
+++ b/backends/go-beego/internal/infrastructure/mail/mailer.go
@@ -82,7 +82,7 @@ const activationTemplate = `<!DOCTYPE html>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{APP_NAME}} — ご利用開始のご案内</title>
 </head>
-<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans JP','Hiragino Sans','Hiragino Kaku Gothic ProN',Meiryo,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
 <tr><td align="center" style="padding:40px 16px;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px;margin:0 auto;">
@@ -90,20 +90,24 @@ const activationTemplate = `<!DOCTYPE html>
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
-<p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;line-height:1.4;letter-spacing:-0.02em;">ご利用開始のご案内</h1>
+<p style="margin:0 0 20px;font-size:14px;line-height:1.7;color:#6b7280;">{{NAME}} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
-下のボタンからご利用を開始してください。
+<strong style="color:#4f46e5;font-weight:600;">{{APP_NAME}}</strong> へのご登録が完了しました。<br>
+以下のボタンからご利用を開始してください。
 </p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
-<tr><td style="border-radius:6px;background-color:#4f46e5;">
-<a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+<tr><td align="center" style="padding:8px 0 24px;">
+<a href="{{ACTIVATE_URL}}" style="display:inline-block;background-color:#4f46e5;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.01em;">ご利用を開始する</a>
 </td></tr>
 </table>
-<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
-<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
-<p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
+<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">ボタンが開かない場合</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
+<tr><td style="padding:12px 16px;word-break:break-all;">
+<a href="{{ACTIVATE_URL}}" style="font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:12px;line-height:1.6;color:#4f46e5;text-decoration:none;">{{ACTIVATE_URL}}</a>
+</td></tr>
+</table>
+<p style="margin:20px 0 0;font-size:12px;line-height:1.65;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">
 <p style="margin:0;font-size:11px;color:#9ca3af;">© {{YEAR}} {{APP_NAME}}</p>

--- a/backends/go-beego/internal/infrastructure/mail/mailer.go
+++ b/backends/go-beego/internal/infrastructure/mail/mailer.go
@@ -40,12 +40,12 @@ func mailSubject(env, subject string) string {
 	return subject
 }
 
-func (m *Mailer) SendAccessToken(to, clientName, token string) {
+func (m *Mailer) SendActivation(to, clientName, activateURL string) {
 	if to == "" {
 		return
 	}
-	subject := mailSubject(m.cfg.AppEnv, fmt.Sprintf("【%s / Beego】アクセストークンのお知らせ", m.cfg.AppName))
-	body := buildAccessTokenHTML(clientName, token, m.cfg.AppName)
+	subject := mailSubject(m.cfg.AppEnv, fmt.Sprintf("【%s / Beego】ご利用開始のご案内", m.cfg.AppName))
+	body := buildActivationHTML(clientName, activateURL, m.cfg.AppName)
 
 	fromHeader := mime.QEncoding.Encode("UTF-8", m.cfg.AppName) + " <" + m.cfg.FromAddress + ">"
 	msg := "MIME-Version: 1.0\r\n" +
@@ -65,22 +65,22 @@ func (m *Mailer) SendAccessToken(to, clientName, token string) {
 	}
 }
 
-func buildAccessTokenHTML(name, token, appName string) string {
+func buildActivationHTML(name, activateURL, appName string) string {
 	year := time.Now().Year()
-	html := accessTokenTemplate
+	html := activationTemplate
 	html = strings.ReplaceAll(html, "{{NAME}}", name)
-	html = strings.ReplaceAll(html, "{{TOKEN}}", token)
+	html = strings.ReplaceAll(html, "{{ACTIVATE_URL}}", activateURL)
 	html = strings.ReplaceAll(html, "{{APP_NAME}}", appName)
 	html = strings.ReplaceAll(html, "{{YEAR}}", fmt.Sprintf("%d", year))
 	return html
 }
 
-const accessTokenTemplate = `<!DOCTYPE html>
+const activationTemplate = `<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{APP_NAME}} — アクセストークン</title>
+<title>{{APP_NAME}} — ご利用開始のご案内</title>
 </head>
 <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
@@ -90,18 +90,19 @@ const accessTokenTemplate = `<!DOCTYPE html>
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">アクセストークンを発行しました</h1>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
 <p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-ご利用の <strong style="color:#4f46e5;">{{APP_NAME}}</strong> 向けにアクセストークンを発行しました。<br>
-以下のトークンは第三者に共有せず、安全な場所で保管してください。
+この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
+下のボタンからご利用を開始してください。
 </p>
-<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">発行されたトークン</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
-<tr><td style="padding:16px 18px;word-break:break-all;">
-<code style="font-family:monospace;font-size:13px;color:#111827;">{{TOKEN}}</code>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+<tr><td style="border-radius:6px;background-color:#4f46e5;">
+<a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
 </td></tr>
 </table>
+<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
+<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
 <p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">

--- a/backends/go-beego/internal/usecase/client/interactor.go
+++ b/backends/go-beego/internal/usecase/client/interactor.go
@@ -118,6 +118,7 @@ func (uc *Interactor) Store(dto StoreDto) (*domclient.StoreVo, error) {
 	return &domclient.StoreVo{
 		ID:          saved.ID,
 		Name:        saved.Name,
+		Identifier:  saved.Identifier,
 		Email:       saved.Email,
 		AccessToken: saved.AccessToken,
 	}, nil

--- a/backends/go-beego/main.go
+++ b/backends/go-beego/main.go
@@ -64,7 +64,7 @@ func main() {
 	mailer := mail.NewMailer(cfg.Mail)
 
 	authH := handler.NewAuthHandler(ormer, newAuthUC, newInviteUC, cfg)
-	clientH := handler.NewClientHandler(ormer, newClientUC, newNotifUC, mailer, jwtHistoryRepo)
+	clientH := handler.NewClientHandler(ormer, newClientUC, newNotifUC, mailer, jwtHistoryRepo, cfg.App.FrontendURL)
 	staffH := handler.NewStaffHandler(ormer, newStaffUC)
 	adminInvitationH := handler.NewAdminInvitationHandler(ormer, newInviteUC)
 	gateH := handler.NewGateHandler(gateUC)

--- a/backends/go-beego/tests/setup_test.go
+++ b/backends/go-beego/tests/setup_test.go
@@ -95,7 +95,7 @@ func buildRouter() http.Handler {
 
 	mailer := mail.NewMailer(testCfg.Mail)
 	authH := handler.NewAuthHandler(testOrmer, newAuthUC, newInviteUC, testCfg)
-	clientH := handler.NewClientHandler(testOrmer, newClientUC, newNotifUC, mailer, nil)
+	clientH := handler.NewClientHandler(testOrmer, newClientUC, newNotifUC, mailer, nil, "")
 	staffH := handler.NewStaffHandler(testOrmer, newStaffUC)
 	gateH := handler.NewGateHandler(gateUC)
 	notificationH := handler.NewNotificationHandler(testOrmer, newNotifUC, testCfg)

--- a/backends/go-echo/internal/domain/client/value_objects.go
+++ b/backends/go-echo/internal/domain/client/value_objects.go
@@ -33,6 +33,7 @@ type DetailVo struct {
 type StoreVo struct {
 	ID          uint64
 	Name        string
+	Identifier  string
 	Email       string
 	AccessToken string
 }

--- a/backends/go-echo/internal/handler/client_handler.go
+++ b/backends/go-echo/internal/handler/client_handler.go
@@ -21,6 +21,7 @@ type ClientHandler struct {
 	newNotifUC  func(*ent.Client) *unotification.Interactor
 	mailer      *mail.Mailer
 	historyRepo domclient.JwtHistoryRepository
+	frontendURL string
 }
 
 func NewClientHandler(
@@ -29,8 +30,9 @@ func NewClientHandler(
 	newNotifUC func(*ent.Client) *unotification.Interactor,
 	mailer *mail.Mailer,
 	historyRepo domclient.JwtHistoryRepository,
+	frontendURL string,
 ) *ClientHandler {
-	return &ClientHandler{db: db, newClientUC: newClientUC, newNotifUC: newNotifUC, mailer: mailer, historyRepo: historyRepo}
+	return &ClientHandler{db: db, newClientUC: newClientUC, newNotifUC: newNotifUC, mailer: mailer, historyRepo: historyRepo, frontendURL: frontendURL}
 }
 
 func (h *ClientHandler) Index(c echo.Context) error {
@@ -99,7 +101,8 @@ func (h *ClientHandler) Store(c echo.Context) error {
 		Title: "新しいクライアントが登録されました", Message: storeVo.Name,
 		MessageType: 1, ExecutorID: executorID, URL: notifURL,
 	})
-	go h.mailer.SendAccessToken(storeVo.Email, storeVo.Name, storeVo.AccessToken)
+	activateURL := h.frontendURL + "/clients/" + storeVo.Identifier + "/qr"
+	go h.mailer.SendActivation(storeVo.Email, storeVo.Name, activateURL)
 	return c.JSON(http.StatusCreated, map[string]interface{}{"id": storeVo.ID})
 }
 

--- a/backends/go-echo/internal/infrastructure/mail/mailer.go
+++ b/backends/go-echo/internal/infrastructure/mail/mailer.go
@@ -40,12 +40,12 @@ func mailSubject(env, subject string) string {
 	return subject
 }
 
-func (m *Mailer) SendAccessToken(to, clientName, token string) {
+func (m *Mailer) SendActivation(to, clientName, activateURL string) {
 	if to == "" {
 		return
 	}
-	subject := mailSubject(m.cfg.AppEnv, fmt.Sprintf("【%s / Echo】アクセストークンのお知らせ", m.cfg.AppName))
-	body := buildAccessTokenHTML(clientName, token, m.cfg.AppName)
+	subject := mailSubject(m.cfg.AppEnv, fmt.Sprintf("【%s / Echo】ご利用開始のご案内", m.cfg.AppName))
+	body := buildActivationHTML(clientName, activateURL, m.cfg.AppName)
 
 	fromHeader := mime.QEncoding.Encode("UTF-8", m.cfg.AppName) + " <" + m.cfg.FromAddress + ">"
 	msg := "MIME-Version: 1.0\r\n" +
@@ -65,22 +65,22 @@ func (m *Mailer) SendAccessToken(to, clientName, token string) {
 	}
 }
 
-func buildAccessTokenHTML(name, token, appName string) string {
+func buildActivationHTML(name, activateURL, appName string) string {
 	year := time.Now().Year()
-	html := accessTokenTemplate
+	html := activationTemplate
 	html = strings.ReplaceAll(html, "{{NAME}}", name)
-	html = strings.ReplaceAll(html, "{{TOKEN}}", token)
+	html = strings.ReplaceAll(html, "{{ACTIVATE_URL}}", activateURL)
 	html = strings.ReplaceAll(html, "{{APP_NAME}}", appName)
 	html = strings.ReplaceAll(html, "{{YEAR}}", fmt.Sprintf("%d", year))
 	return html
 }
 
-const accessTokenTemplate = `<!DOCTYPE html>
+const activationTemplate = `<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{APP_NAME}} — アクセストークン</title>
+<title>{{APP_NAME}} — ご利用開始のご案内</title>
 </head>
 <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
@@ -90,18 +90,19 @@ const accessTokenTemplate = `<!DOCTYPE html>
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">アクセストークンを発行しました</h1>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
 <p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-ご利用の <strong style="color:#4f46e5;">{{APP_NAME}}</strong> 向けにアクセストークンを発行しました。<br>
-以下のトークンは第三者に共有せず、安全な場所で保管してください。
+この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
+下のボタンからご利用を開始してください。
 </p>
-<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">発行されたトークン</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
-<tr><td style="padding:16px 18px;word-break:break-all;">
-<code style="font-family:monospace;font-size:13px;color:#111827;">{{TOKEN}}</code>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+<tr><td style="border-radius:6px;background-color:#4f46e5;">
+<a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
 </td></tr>
 </table>
+<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
+<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
 <p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">

--- a/backends/go-echo/internal/infrastructure/mail/mailer.go
+++ b/backends/go-echo/internal/infrastructure/mail/mailer.go
@@ -82,7 +82,7 @@ const activationTemplate = `<!DOCTYPE html>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{APP_NAME}} — ご利用開始のご案内</title>
 </head>
-<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans JP','Hiragino Sans','Hiragino Kaku Gothic ProN',Meiryo,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
 <tr><td align="center" style="padding:40px 16px;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px;margin:0 auto;">
@@ -90,20 +90,24 @@ const activationTemplate = `<!DOCTYPE html>
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
-<p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;line-height:1.4;letter-spacing:-0.02em;">ご利用開始のご案内</h1>
+<p style="margin:0 0 20px;font-size:14px;line-height:1.7;color:#6b7280;">{{NAME}} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
-下のボタンからご利用を開始してください。
+<strong style="color:#4f46e5;font-weight:600;">{{APP_NAME}}</strong> へのご登録が完了しました。<br>
+以下のボタンからご利用を開始してください。
 </p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
-<tr><td style="border-radius:6px;background-color:#4f46e5;">
-<a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+<tr><td align="center" style="padding:8px 0 24px;">
+<a href="{{ACTIVATE_URL}}" style="display:inline-block;background-color:#4f46e5;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.01em;">ご利用を開始する</a>
 </td></tr>
 </table>
-<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
-<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
-<p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
+<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">ボタンが開かない場合</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
+<tr><td style="padding:12px 16px;word-break:break-all;">
+<a href="{{ACTIVATE_URL}}" style="font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:12px;line-height:1.6;color:#4f46e5;text-decoration:none;">{{ACTIVATE_URL}}</a>
+</td></tr>
+</table>
+<p style="margin:20px 0 0;font-size:12px;line-height:1.65;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">
 <p style="margin:0;font-size:11px;color:#9ca3af;">© {{YEAR}} {{APP_NAME}}</p>

--- a/backends/go-echo/internal/usecase/client/interactor.go
+++ b/backends/go-echo/internal/usecase/client/interactor.go
@@ -118,6 +118,7 @@ func (uc *Interactor) Store(dto StoreDto) (*domclient.StoreVo, error) {
 	return &domclient.StoreVo{
 		ID:          saved.ID,
 		Name:        saved.Name,
+		Identifier:  saved.Identifier,
 		Email:       saved.Email,
 		AccessToken: saved.AccessToken,
 	}, nil

--- a/backends/go-echo/main.go
+++ b/backends/go-echo/main.go
@@ -61,7 +61,7 @@ func main() {
 	mailer := mail.NewMailer(cfg.Mail)
 
 	authH := handler.NewAuthHandler(database, newAuthUC, newInviteUC, cfg)
-	clientH := handler.NewClientHandler(database, newClientUC, newNotifUC, mailer, jwtHistoryRepo)
+	clientH := handler.NewClientHandler(database, newClientUC, newNotifUC, mailer, jwtHistoryRepo, cfg.App.FrontendURL)
 	staffH := handler.NewStaffHandler(database, newStaffUC)
 	adminInvitationH := handler.NewAdminInvitationHandler(database, newInviteUC)
 	gateH := handler.NewGateHandler(gateUC)

--- a/backends/go-echo/tests/setup_test.go
+++ b/backends/go-echo/tests/setup_test.go
@@ -97,7 +97,7 @@ func buildRouter() *echo.Echo {
 
 	mailer := mail.NewMailer(testCfg.Mail)
 	authH := handler.NewAuthHandler(testDB, newAuthUC, newInviteUC, testCfg)
-	clientH := handler.NewClientHandler(testDB, newClientUC, newNotifUC, mailer, nil)
+	clientH := handler.NewClientHandler(testDB, newClientUC, newNotifUC, mailer, nil, "")
 	staffH := handler.NewStaffHandler(testDB, newStaffUC)
 	gateH := handler.NewGateHandler(gateUC)
 	notificationH := handler.NewNotificationHandler(testDB, newNotifUC, testCfg)

--- a/backends/go-gin/cmd/main.go
+++ b/backends/go-gin/cmd/main.go
@@ -73,7 +73,7 @@ func main() {
 
 	// --- Handlers ---
 	authH := handler.NewAuthHandler(database, newAuthUC, newInviteUC, cfg)
-	clientH := handler.NewClientHandler(database, newClientUC, newNotifUC, mailer, jwtHistoryRepo)
+	clientH := handler.NewClientHandler(database, newClientUC, newNotifUC, mailer, jwtHistoryRepo, cfg.App.FrontendURL)
 	staffH := handler.NewStaffHandler(database, newStaffUC)
 	adminInvitationH := handler.NewAdminInvitationHandler(database, newInviteUC)
 	gateH := handler.NewGateHandler(gateUC)

--- a/backends/go-gin/internal/domain/client/value_objects.go
+++ b/backends/go-gin/internal/domain/client/value_objects.go
@@ -37,6 +37,7 @@ type DetailVo struct {
 type StoreVo struct {
 	ID          uint64
 	Name        string
+	Identifier  string
 	Email       string
 	AccessToken string
 }

--- a/backends/go-gin/internal/handler/client_handler.go
+++ b/backends/go-gin/internal/handler/client_handler.go
@@ -22,6 +22,7 @@ type ClientHandler struct {
 	newNotifUC  func(*gorm.DB) *unotification.Interactor
 	mailer      *mail.Mailer
 	historyRepo domclient.JwtHistoryRepository
+	frontendURL string
 }
 
 // NewClientHandler は ClientHandler を生成します。
@@ -31,12 +32,14 @@ type ClientHandler struct {
 // newNotifUC: 通知ユースケースファクトリ
 // mailer: メール送信サービス
 // historyRepo: JWT 履歴リポジトリ
+// frontendURL: フロントエンド URL
 func NewClientHandler(
 	db *gorm.DB,
 	newClientUC func(*gorm.DB) *uclient.Interactor,
 	newNotifUC func(*gorm.DB) *unotification.Interactor,
 	mailer *mail.Mailer,
 	historyRepo domclient.JwtHistoryRepository,
+	frontendURL string,
 ) *ClientHandler {
 	return &ClientHandler{
 		db:          db,
@@ -44,6 +47,7 @@ func NewClientHandler(
 		newNotifUC:  newNotifUC,
 		mailer:      mailer,
 		historyRepo: historyRepo,
+		frontendURL: frontendURL,
 	}
 }
 
@@ -140,8 +144,9 @@ func (h *ClientHandler) Store(c *gin.Context) {
 		URL:         notifURL,
 	})
 
-	// アクセストークンメール送信（非同期）
-	go h.mailer.SendAccessToken(storeVo.Email, storeVo.Name, storeVo.AccessToken)
+	// ご利用開始のご案内メール送信（非同期）
+	activateURL := h.frontendURL + "/clients/" + storeVo.Identifier + "/qr"
+	go h.mailer.SendActivation(storeVo.Email, storeVo.Name, activateURL)
 
 	c.JSON(http.StatusCreated, gin.H{"id": storeVo.ID})
 }

--- a/backends/go-gin/internal/infrastructure/mail/mailer.go
+++ b/backends/go-gin/internal/infrastructure/mail/mailer.go
@@ -88,7 +88,7 @@ const activationTemplate = `<!DOCTYPE html>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{APP_NAME}} — ご利用開始のご案内</title>
 </head>
-<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans JP','Hiragino Sans','Hiragino Kaku Gothic ProN',Meiryo,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
 <tr><td align="center" style="padding:40px 16px;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px;margin:0 auto;">
@@ -96,20 +96,24 @@ const activationTemplate = `<!DOCTYPE html>
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
-<p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;line-height:1.4;letter-spacing:-0.02em;">ご利用開始のご案内</h1>
+<p style="margin:0 0 20px;font-size:14px;line-height:1.7;color:#6b7280;">{{NAME}} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
-下のボタンからご利用を開始してください。
+<strong style="color:#4f46e5;font-weight:600;">{{APP_NAME}}</strong> へのご登録が完了しました。<br>
+以下のボタンからご利用を開始してください。
 </p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
-<tr><td style="border-radius:6px;background-color:#4f46e5;">
-<a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+<tr><td align="center" style="padding:8px 0 24px;">
+<a href="{{ACTIVATE_URL}}" style="display:inline-block;background-color:#4f46e5;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.01em;">ご利用を開始する</a>
 </td></tr>
 </table>
-<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
-<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
-<p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
+<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">ボタンが開かない場合</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
+<tr><td style="padding:12px 16px;word-break:break-all;">
+<a href="{{ACTIVATE_URL}}" style="font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:12px;line-height:1.6;color:#4f46e5;text-decoration:none;">{{ACTIVATE_URL}}</a>
+</td></tr>
+</table>
+<p style="margin:20px 0 0;font-size:12px;line-height:1.65;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">
 <p style="margin:0;font-size:11px;color:#9ca3af;">© {{YEAR}} {{APP_NAME}}</p>

--- a/backends/go-gin/internal/infrastructure/mail/mailer.go
+++ b/backends/go-gin/internal/infrastructure/mail/mailer.go
@@ -45,13 +45,13 @@ func mailSubject(env, subject string) string {
 	return subject
 }
 
-// SendAccessToken はクライアントにアクセストークンをメールで送信します。
-func (m *Mailer) SendAccessToken(to, clientName, token string) {
+// SendActivation はクライアントにご利用開始のご案内をメールで送信します。
+func (m *Mailer) SendActivation(to, clientName, activateURL string) {
 	if to == "" {
 		return
 	}
-	subject := mailSubject(m.cfg.AppEnv, fmt.Sprintf("【%s / Go】アクセストークンのお知らせ", m.cfg.AppName))
-	body := buildAccessTokenHTML(clientName, token, m.cfg.AppName)
+	subject := mailSubject(m.cfg.AppEnv, fmt.Sprintf("【%s / Go】ご利用開始のご案内", m.cfg.AppName))
+	body := buildActivationHTML(clientName, activateURL, m.cfg.AppName)
 
 	fromHeader := mime.QEncoding.Encode("UTF-8", m.cfg.AppName) + " <" + m.cfg.FromAddress + ">"
 	msg := "MIME-Version: 1.0\r\n" +
@@ -71,22 +71,22 @@ func (m *Mailer) SendAccessToken(to, clientName, token string) {
 	}
 }
 
-func buildAccessTokenHTML(name, token, appName string) string {
+func buildActivationHTML(name, activateURL, appName string) string {
 	year := time.Now().Year()
-	html := accessTokenTemplate
+	html := activationTemplate
 	html = strings.ReplaceAll(html, "{{NAME}}", name)
-	html = strings.ReplaceAll(html, "{{TOKEN}}", token)
+	html = strings.ReplaceAll(html, "{{ACTIVATE_URL}}", activateURL)
 	html = strings.ReplaceAll(html, "{{APP_NAME}}", appName)
 	html = strings.ReplaceAll(html, "{{YEAR}}", fmt.Sprintf("%d", year))
 	return html
 }
 
-const accessTokenTemplate = `<!DOCTYPE html>
+const activationTemplate = `<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{APP_NAME}} — アクセストークン</title>
+<title>{{APP_NAME}} — ご利用開始のご案内</title>
 </head>
 <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
@@ -96,18 +96,19 @@ const accessTokenTemplate = `<!DOCTYPE html>
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">アクセストークンを発行しました</h1>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
 <p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-ご利用の <strong style="color:#4f46e5;">{{APP_NAME}}</strong> 向けにアクセストークンを発行しました。<br>
-以下のトークンは第三者に共有せず、安全な場所で保管してください。
+この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
+下のボタンからご利用を開始してください。
 </p>
-<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">発行されたトークン</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
-<tr><td style="padding:16px 18px;word-break:break-all;">
-<code style="font-family:monospace;font-size:13px;color:#111827;">{{TOKEN}}</code>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+<tr><td style="border-radius:6px;background-color:#4f46e5;">
+<a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
 </td></tr>
 </table>
+<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
+<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
 <p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">

--- a/backends/go-gin/internal/usecase/client/interactor.go
+++ b/backends/go-gin/internal/usecase/client/interactor.go
@@ -250,6 +250,7 @@ func (uc *Interactor) Store(dto StoreDto) (*domclient.StoreVo, error) {
 	return &domclient.StoreVo{
 		ID:          saved.ID,
 		Name:        saved.Name,
+		Identifier:  saved.Identifier,
 		Email:       saved.Email,
 		AccessToken: saved.AccessToken,
 	}, nil

--- a/backends/go-gin/tests/setup_test.go
+++ b/backends/go-gin/tests/setup_test.go
@@ -101,7 +101,7 @@ func buildRouter() *gin.Engine {
 
 	mailer := mail.NewMailer(testCfg.Mail)
 	authH := handler.NewAuthHandler(testDB, newAuthUC, newInviteUC, testCfg)
-	clientH := handler.NewClientHandler(testDB, newClientUC, newNotifUC, mailer, nil)
+	clientH := handler.NewClientHandler(testDB, newClientUC, newNotifUC, mailer, nil, "")
 	staffH := handler.NewStaffHandler(testDB, newStaffUC)
 	gateH := handler.NewGateHandler(gateUC)
 	notificationH := handler.NewNotificationHandler(testDB, newNotifUC, testCfg)

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/Application.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/Application.kt
@@ -55,7 +55,7 @@ fun Application.module(cfg: Config) {
     val mailer         = Mailer(cfg.mail)
 
     val authH         = AuthHandler(authUC, invitationUC, cfg)
-    val clientH       = ClientHandler(clientUC, notificationUC, mailer, jwtHistoryRepo)
+    val clientH       = ClientHandler(clientUC, notificationUC, mailer, jwtHistoryRepo, cfg.app.frontendUrl)
     val staffH        = StaffHandler(staffUC)
     val adminInvH     = AdminInvitationHandler(invitationUC)
     val gateH         = GateHandler(gateUC)

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/client/ValueObjects.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/client/ValueObjects.kt
@@ -53,6 +53,7 @@ data class DetailVo(
 data class StoreResultVo(
     val id:          Long,
     val name:        String,
+    val identifier:  String,
     val email:       String,
     val accessToken: String,
 )

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/handler/ClientHandler.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/handler/ClientHandler.kt
@@ -44,6 +44,7 @@ class ClientHandler(
     private val notificationUC: NotificationUC,
     private val mailer: Mailer,
     private val jwtHistoryRepo: JwtHistoryRepository,
+    private val frontendUrl: String,
 ) {
 
     /**
@@ -130,8 +131,9 @@ class ClientHandler(
             ))
             c
         }
+        val activateUrl = "$frontendUrl/clients/${client.identifier}/qr"
         call.application.launch {
-            mailer.sendAccessToken(client.email, client.name, client.accessToken)
+            mailer.sendActivation(client.email, client.name, activateUrl)
         }
         call.respond(HttpStatusCode.Created, buildJsonObject { put("id", client.id) })
     }

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/mail/Mailer.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/mail/Mailer.kt
@@ -24,17 +24,17 @@ import java.util.Properties
 class Mailer(private val cfg: MailConfig) {
 
     /**
-     * クライアントへアクセストークン通知メールを送信します。
+     * クライアントへご利用開始のご案内メールを送信します。
      *
      * @param to 宛先メールアドレス
      * @param clientName クライアント名
-     * @param token アクセストークン
+     * @param activateUrl QRページURL
      */
-    fun sendAccessToken(to: String, clientName: String, token: String) {
+    fun sendActivation(to: String, clientName: String, activateUrl: String) {
         if (to.isBlank()) return
 
-        val subject = mailSubject("【${cfg.appName} / Kotlin】アクセストークンのお知らせ")
-        val body = buildAccessTokenHtml(clientName, token, cfg.appName)
+        val subject = mailSubject("【${cfg.appName} / Kotlin】ご利用開始のご案内")
+        val body = buildActivationHtml(clientName, activateUrl, cfg.appName)
 
         val props = Properties().apply {
             put("mail.smtp.host", cfg.host)
@@ -83,28 +83,28 @@ class Mailer(private val cfg: MailConfig) {
 }
 
 /**
- * アクセストークン通知メールの HTML を生成します。
+ * ご利用開始のご案内メールの HTML を生成します。
  *
  * @param name クライアント名
- * @param token アクセストークン
+ * @param activateUrl QRページURL
  * @param appName アプリケーション名
  * @return HTML 文字列
  */
-private fun buildAccessTokenHtml(name: String, token: String, appName: String): String {
+private fun buildActivationHtml(name: String, activateUrl: String, appName: String): String {
     val year = Year.now().value
-    return ACCESS_TOKEN_TEMPLATE
+    return ACTIVATION_TEMPLATE
         .replace("{{NAME}}", name)
-        .replace("{{TOKEN}}", token)
+        .replace("{{ACTIVATE_URL}}", activateUrl)
         .replace("{{APP_NAME}}", appName)
         .replace("{{YEAR}}", year.toString())
 }
 
-private val ACCESS_TOKEN_TEMPLATE = """<!DOCTYPE html>
+private val ACTIVATION_TEMPLATE = """<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{APP_NAME}} — アクセストークン</title>
+<title>{{APP_NAME}} — ご利用開始のご案内</title>
 </head>
 <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
@@ -114,18 +114,19 @@ private val ACCESS_TOKEN_TEMPLATE = """<!DOCTYPE html>
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">アクセストークンを発行しました</h1>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
 <p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-ご利用の <strong style="color:#4f46e5;">{{APP_NAME}}</strong> 向けにアクセストークンを発行しました。<br>
-以下のトークンは第三者に共有せず、安全な場所で保管してください。
+この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
+下のボタンからご利用を開始してください。
 </p>
-<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">発行されたトークン</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
-<tr><td style="padding:16px 18px;word-break:break-all;">
-<code style="font-family:monospace;font-size:13px;color:#111827;">{{TOKEN}}</code>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+<tr><td style="border-radius:6px;background-color:#4f46e5;">
+<a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
 </td></tr>
 </table>
+<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
+<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
 <p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/mail/Mailer.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/mail/Mailer.kt
@@ -106,7 +106,7 @@ private val ACTIVATION_TEMPLATE = """<!DOCTYPE html>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{APP_NAME}} — ご利用開始のご案内</title>
 </head>
-<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans JP','Hiragino Sans','Hiragino Kaku Gothic ProN',Meiryo,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
 <tr><td align="center" style="padding:40px 16px;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px;margin:0 auto;">
@@ -114,20 +114,24 @@ private val ACTIVATION_TEMPLATE = """<!DOCTYPE html>
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
-<p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;line-height:1.4;letter-spacing:-0.02em;">ご利用開始のご案内</h1>
+<p style="margin:0 0 20px;font-size:14px;line-height:1.7;color:#6b7280;">{{NAME}} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
-下のボタンからご利用を開始してください。
+<strong style="color:#4f46e5;font-weight:600;">{{APP_NAME}}</strong> へのご登録が完了しました。<br>
+以下のボタンからご利用を開始してください。
 </p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
-<tr><td style="border-radius:6px;background-color:#4f46e5;">
-<a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+<tr><td align="center" style="padding:8px 0 24px;">
+<a href="{{ACTIVATE_URL}}" style="display:inline-block;background-color:#4f46e5;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.01em;">ご利用を開始する</a>
 </td></tr>
 </table>
-<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
-<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
-<p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
+<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">ボタンが開かない場合</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
+<tr><td style="padding:12px 16px;word-break:break-all;">
+<a href="{{ACTIVATE_URL}}" style="font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:12px;line-height:1.6;color:#4f46e5;text-decoration:none;">{{ACTIVATE_URL}}</a>
+</td></tr>
+</table>
+<p style="margin:20px 0 0;font-size:12px;line-height:1.65;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">
 <p style="margin:0;font-size:11px;color:#9ca3af;">© {{YEAR}} {{APP_NAME}}</p>

--- a/backends/python-fastapi/app/infrastructure/mail/mailer.py
+++ b/backends/python-fastapi/app/infrastructure/mail/mailer.py
@@ -36,19 +36,19 @@ def _mail_subject(env: str, subject: str) -> str:
     return f"[{label}]{subject}" if label else subject
 
 
-def send_access_token(to: str, client_name: str, token: str) -> None:
-    """クライアントにアクセストークンをメール送信します。
+def send_activation(to: str, client_name: str, activate_url: str) -> None:
+    """クライアントにご利用開始のご案内をメール送信します。
 
     Args:
         to: 送信先メールアドレス
         client_name: クライアント名
-        token: アクセストークン
+        activate_url: QRページURL
     """
     if not to:
         return
     settings = get_settings()
-    subject = _mail_subject(settings.app_env, f"【{settings.app_name} / Python】アクセストークンのお知らせ")
-    html = _build_html(client_name, token, settings.app_name)
+    subject = _mail_subject(settings.app_env, f"【{settings.app_name} / Python】ご利用開始のご案内")
+    html = _build_html(client_name, activate_url, settings.app_name)
 
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject
@@ -65,12 +65,12 @@ def send_access_token(to: str, client_name: str, token: str) -> None:
         logger.error("mail send error: %s", e)
 
 
-def _build_html(name: str, token: str, app_name: str) -> str:
-    """アクセストークン通知メールの HTML 本文を生成します。
+def _build_html(name: str, activate_url: str, app_name: str) -> str:
+    """ご利用開始のご案内メールの HTML 本文を生成します。
 
     Args:
         name: クライアント名
-        token: アクセストークン
+        activate_url: QRページURL
         app_name: アプリケーション名
 
     Returns:
@@ -82,7 +82,7 @@ def _build_html(name: str, token: str, app_name: str) -> str:
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{app_name} — アクセストークン</title>
+<title>{app_name} — ご利用開始のご案内</title>
 </head>
 <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
@@ -92,18 +92,19 @@ def _build_html(name: str, token: str, app_name: str) -> str:
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{app_name}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">アクセストークンを発行しました</h1>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
 <p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{name} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-ご利用の <strong style="color:#4f46e5;">{app_name}</strong> 向けにアクセストークンを発行しました。<br>
-以下のトークンは第三者に共有せず、安全な場所で保管してください。
+この度は <strong style="color:#4f46e5;">{app_name}</strong> にご登録いただきありがとうございます。<br>
+下のボタンからご利用を開始してください。
 </p>
-<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">発行されたトークン</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
-<tr><td style="padding:16px 18px;word-break:break-all;">
-<code style="font-family:monospace;font-size:13px;color:#111827;">{token}</code>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+<tr><td style="border-radius:6px;background-color:#4f46e5;">
+<a href="{activate_url}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
 </td></tr>
 </table>
+<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
+<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{activate_url}</p>
 <p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">

--- a/backends/python-fastapi/app/infrastructure/mail/mailer.py
+++ b/backends/python-fastapi/app/infrastructure/mail/mailer.py
@@ -84,7 +84,7 @@ def _build_html(name: str, activate_url: str, app_name: str) -> str:
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{app_name} — ご利用開始のご案内</title>
 </head>
-<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans JP','Hiragino Sans','Hiragino Kaku Gothic ProN',Meiryo,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
 <tr><td align="center" style="padding:40px 16px;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px;margin:0 auto;">
@@ -92,20 +92,24 @@ def _build_html(name: str, activate_url: str, app_name: str) -> str:
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{app_name}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
-<p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{name} 様</p>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;line-height:1.4;letter-spacing:-0.02em;">ご利用開始のご案内</h1>
+<p style="margin:0 0 20px;font-size:14px;line-height:1.7;color:#6b7280;">{name} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-この度は <strong style="color:#4f46e5;">{app_name}</strong> にご登録いただきありがとうございます。<br>
-下のボタンからご利用を開始してください。
+<strong style="color:#4f46e5;font-weight:600;">{app_name}</strong> へのご登録が完了しました。<br>
+以下のボタンからご利用を開始してください。
 </p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
-<tr><td style="border-radius:6px;background-color:#4f46e5;">
-<a href="{activate_url}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+<tr><td align="center" style="padding:8px 0 24px;">
+<a href="{activate_url}" style="display:inline-block;background-color:#4f46e5;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.01em;">ご利用を開始する</a>
 </td></tr>
 </table>
-<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
-<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{activate_url}</p>
-<p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
+<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">ボタンが開かない場合</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
+<tr><td style="padding:12px 16px;word-break:break-all;">
+<a href="{activate_url}" style="font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:12px;line-height:1.6;color:#4f46e5;text-decoration:none;">{activate_url}</a>
+</td></tr>
+</table>
+<p style="margin:20px 0 0;font-size:12px;line-height:1.65;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">
 <p style="margin:0;font-size:11px;color:#9ca3af;">© {year} {app_name}</p>

--- a/backends/python-fastapi/app/routers/clients.py
+++ b/backends/python-fastapi/app/routers/clients.py
@@ -13,7 +13,8 @@ from app.infrastructure.persistence.sqlalchemy_jwt_history_repository import Sql
 from app.usecase.client.interactor import ClientInteractor
 from app.usecase.client.dto import ClientStoreDto, ClientUpdateDto, ClientIdentifierDto
 from app.usecase.notification.interactor import NotificationInteractor
-from app.infrastructure.mail.mailer import send_access_token
+from app.infrastructure.mail.mailer import send_activation
+from app.config.settings import get_settings
 
 router = APIRouter()
 
@@ -113,9 +114,11 @@ def store(
         message_type=1,
     )
 
+    settings = get_settings()
+    activate_url = f"{settings.frontend_url}/clients/{result.identifier}/qr"
     threading.Thread(
-        target=send_access_token,
-        args=(result.email, result.name, result.token),
+        target=send_activation,
+        args=(result.email, result.name, activate_url),
         daemon=True,
     ).start()
 

--- a/backends/ruby-hanami/app/actions/clients/store.rb
+++ b/backends/ruby-hanami/app/actions/clients/store.rb
@@ -43,7 +43,8 @@ module Authorization
             )
             c
           end
-          Thread.new { container[:mailer].send_access_token(client.email, client.name, client.access_token) }
+          activate_url = "#{container[:cfg].app.frontend_url}/clients/#{client.identifier}/qr"
+          Thread.new { container[:mailer].send_activation(client.email, client.name, activate_url) }
 
           json_response(response, { id: client.id }, status: 201)
         end

--- a/backends/ruby-hanami/app/domain/client/value_objects.rb
+++ b/backends/ruby-hanami/app/domain/client/value_objects.rb
@@ -18,7 +18,7 @@ module Domain
     )
 
     # クライアント登録結果の値オブジェクトです。
-    StoreResultVo = Struct.new(:id, :name, :email, :access_token, keyword_init: true)
+    StoreResultVo = Struct.new(:id, :name, :identifier, :email, :access_token, keyword_init: true)
 
     # QRコードデータの値オブジェクトです。
     QrVo = Struct.new(:identifier, :deeplink_url, keyword_init: true)

--- a/backends/ruby-hanami/app/infrastructure/mail/mailer.rb
+++ b/backends/ruby-hanami/app/infrastructure/mail/mailer.rb
@@ -81,7 +81,7 @@ module Infrastructure
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{{APP_NAME}} — ご利用開始のご案内</title>
         </head>
-        <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+        <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans JP','Hiragino Sans','Hiragino Kaku Gothic ProN',Meiryo,sans-serif;">
         <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
         <tr><td align="center" style="padding:40px 16px;">
         <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px;margin:0 auto;">
@@ -89,20 +89,24 @@ module Infrastructure
         <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
         </td></tr>
         <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-        <h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
-        <p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
+        <h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;line-height:1.4;letter-spacing:-0.02em;">ご利用開始のご案内</h1>
+        <p style="margin:0 0 20px;font-size:14px;line-height:1.7;color:#6b7280;">{{NAME}} 様</p>
         <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-        この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
-        下のボタンからご利用を開始してください。
+        <strong style="color:#4f46e5;font-weight:600;">{{APP_NAME}}</strong> へのご登録が完了しました。<br>
+        以下のボタンからご利用を開始してください。
         </p>
-        <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
-        <tr><td style="border-radius:6px;background-color:#4f46e5;">
-        <a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+        <tr><td align="center" style="padding:8px 0 24px;">
+        <a href="{{ACTIVATE_URL}}" style="display:inline-block;background-color:#4f46e5;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.01em;">ご利用を開始する</a>
         </td></tr>
         </table>
-        <p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
-        <p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
-        <p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
+        <p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">ボタンが開かない場合</p>
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
+        <tr><td style="padding:12px 16px;word-break:break-all;">
+        <a href="{{ACTIVATE_URL}}" style="font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:12px;line-height:1.6;color:#4f46e5;text-decoration:none;">{{ACTIVATE_URL}}</a>
+        </td></tr>
+        </table>
+        <p style="margin:20px 0 0;font-size:12px;line-height:1.65;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
         </td></tr>
         <tr><td align="center" style="padding:24px 16px 8px;">
         <p style="margin:0;font-size:11px;color:#9ca3af;">© {{YEAR}} {{APP_NAME}}</p>

--- a/backends/ruby-hanami/app/infrastructure/mail/mailer.rb
+++ b/backends/ruby-hanami/app/infrastructure/mail/mailer.rb
@@ -20,13 +20,13 @@ module Infrastructure
 
       # @param to [String] 宛先メールアドレス
       # @param client_name [String] クライアント名
-      # @param token [String] アクセストークン
+      # @param activate_url [String] QRページURL
       # @return [void]
-      def send_access_token(to, client_name, token)
+      def send_activation(to, client_name, activate_url)
         return if to.nil? || to.empty?
 
-        subject = mail_subject("【#{@cfg.app_name} / Ruby Hanami】アクセストークンのお知らせ")
-        body    = build_access_token_html(client_name, token)
+        subject = mail_subject("【#{@cfg.app_name} / Ruby Hanami】ご利用開始のご案内")
+        body    = build_activation_html(client_name, activate_url)
 
         message = build_message(to, subject, body)
         smtp_send(to, message)
@@ -64,22 +64,22 @@ module Infrastructure
         end
       end
 
-      def build_access_token_html(name, token)
+      def build_activation_html(name, activate_url)
         year = Time.now.year
-        ACCESS_TOKEN_TEMPLATE
+        ACTIVATION_TEMPLATE
           .gsub("{{NAME}}", name)
-          .gsub("{{TOKEN}}", token)
+          .gsub("{{ACTIVATE_URL}}", activate_url)
           .gsub("{{APP_NAME}}", @cfg.app_name)
           .gsub("{{YEAR}}", year.to_s)
       end
 
-      ACCESS_TOKEN_TEMPLATE = <<~HTML
+      ACTIVATION_TEMPLATE = <<~HTML
         <!DOCTYPE html>
         <html lang="ja">
         <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>{{APP_NAME}} — アクセストークン</title>
+        <title>{{APP_NAME}} — ご利用開始のご案内</title>
         </head>
         <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
         <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
@@ -89,18 +89,19 @@ module Infrastructure
         <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
         </td></tr>
         <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-        <h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">アクセストークンを発行しました</h1>
+        <h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
         <p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
         <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-        ご利用の <strong style="color:#4f46e5;">{{APP_NAME}}</strong> 向けにアクセストークンを発行しました。<br>
-        以下のトークンは第三者に共有せず、安全な場所で保管してください。
+        この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
+        下のボタンからご利用を開始してください。
         </p>
-        <p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">発行されたトークン</p>
-        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
-        <tr><td style="padding:16px 18px;word-break:break-all;">
-        <code style="font-family:monospace;font-size:13px;color:#111827;">{{TOKEN}}</code>
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+        <tr><td style="border-radius:6px;background-color:#4f46e5;">
+        <a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
         </td></tr>
         </table>
+        <p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
+        <p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
         <p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
         </td></tr>
         <tr><td align="center" style="padding:24px 16px 8px;">

--- a/backends/ruby-hanami/app/usecase/client/interactor.rb
+++ b/backends/ruby-hanami/app/usecase/client/interactor.rb
@@ -72,6 +72,7 @@ module UseCase
         Domain::Client::StoreResultVo.new(
           id:           saved.id,
           name:         saved.name,
+          identifier:   saved.identifier,
           email:        saved.email,
           access_token: saved.access_token,
         )

--- a/backends/ruby-rails/app/controllers/api/clients_controller.rb
+++ b/backends/ruby-rails/app/controllers/api/clients_controller.rb
@@ -93,7 +93,8 @@ class Api::ClientsController < Api::BaseController
       )
       c
     end
-    Thread.new { container[:mailer].send_access_token(client.email, client.name, client.access_token) }
+    activate_url = "#{container[:cfg].app.frontend_url}/clients/#{client.identifier}/qr"
+    Thread.new { container[:mailer].send_activation(client.email, client.name, activate_url) }
 
     render json: { id: client.id }, status: :created
   end

--- a/backends/ruby-rails/app/domain/client/value_objects.rb
+++ b/backends/ruby-rails/app/domain/client/value_objects.rb
@@ -18,7 +18,7 @@ module Domain
     )
 
     # クライアント登録結果の値オブジェクトです。
-    StoreResultVo = Struct.new(:id, :name, :email, :access_token, keyword_init: true)
+    StoreResultVo = Struct.new(:id, :name, :identifier, :email, :access_token, keyword_init: true)
 
     # QRコードデータの値オブジェクトです。
     QrVo = Struct.new(:identifier, :deeplink_url, keyword_init: true)

--- a/backends/ruby-rails/app/infrastructure/mail/mailer.rb
+++ b/backends/ruby-rails/app/infrastructure/mail/mailer.rb
@@ -95,7 +95,7 @@ module Infrastructure
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{{APP_NAME}} — ご利用開始のご案内</title>
         </head>
-        <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+        <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans JP','Hiragino Sans','Hiragino Kaku Gothic ProN',Meiryo,sans-serif;">
         <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
         <tr><td align="center" style="padding:40px 16px;">
         <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px;margin:0 auto;">
@@ -103,20 +103,24 @@ module Infrastructure
         <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
         </td></tr>
         <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-        <h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
-        <p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
+        <h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;line-height:1.4;letter-spacing:-0.02em;">ご利用開始のご案内</h1>
+        <p style="margin:0 0 20px;font-size:14px;line-height:1.7;color:#6b7280;">{{NAME}} 様</p>
         <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-        この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
-        下のボタンからご利用を開始してください。
+        <strong style="color:#4f46e5;font-weight:600;">{{APP_NAME}}</strong> へのご登録が完了しました。<br>
+        以下のボタンからご利用を開始してください。
         </p>
-        <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
-        <tr><td style="border-radius:6px;background-color:#4f46e5;">
-        <a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+        <tr><td align="center" style="padding:8px 0 24px;">
+        <a href="{{ACTIVATE_URL}}" style="display:inline-block;background-color:#4f46e5;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.01em;">ご利用を開始する</a>
         </td></tr>
         </table>
-        <p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
-        <p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
-        <p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
+        <p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">ボタンが開かない場合</p>
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
+        <tr><td style="padding:12px 16px;word-break:break-all;">
+        <a href="{{ACTIVATE_URL}}" style="font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:12px;line-height:1.6;color:#4f46e5;text-decoration:none;">{{ACTIVATE_URL}}</a>
+        </td></tr>
+        </table>
+        <p style="margin:20px 0 0;font-size:12px;line-height:1.65;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
         </td></tr>
         <tr><td align="center" style="padding:24px 16px 8px;">
         <p style="margin:0;font-size:11px;color:#9ca3af;">© {{YEAR}} {{APP_NAME}}</p>

--- a/backends/ruby-rails/app/infrastructure/mail/mailer.rb
+++ b/backends/ruby-rails/app/infrastructure/mail/mailer.rb
@@ -17,16 +17,16 @@ module Infrastructure
         @cfg = cfg
       end
 
-      # クライアントへアクセストークン通知メールを送信します。
+      # クライアントへご利用開始のご案内メールを送信します。
       # @param to [String] 宛先メールアドレス
       # @param client_name [String] クライアント名
-      # @param token [String] アクセストークン
+      # @param activate_url [String] QRページURL
       # @return [void]
-      def send_access_token(to, client_name, token)
+      def send_activation(to, client_name, activate_url)
         return if to.nil? || to.empty?
 
-        subject = mail_subject("【#{@cfg.app_name} / Ruby on Rails】アクセストークンのお知らせ")
-        body    = build_access_token_html(client_name, token)
+        subject = mail_subject("【#{@cfg.app_name} / Ruby on Rails】ご利用開始のご案内")
+        body    = build_activation_html(client_name, activate_url)
 
         message = build_message(to, subject, body)
         smtp_send(to, message)
@@ -76,24 +76,24 @@ module Infrastructure
       end
 
       # @param name [String] クライアント名
-      # @param token [String] アクセストークン
+      # @param activate_url [String] QRページURL
       # @return [String] HTML 文字列
-      def build_access_token_html(name, token)
+      def build_activation_html(name, activate_url)
         year = Time.now.year
-        ACCESS_TOKEN_TEMPLATE
+        ACTIVATION_TEMPLATE
           .gsub("{{NAME}}", name)
-          .gsub("{{TOKEN}}", token)
+          .gsub("{{ACTIVATE_URL}}", activate_url)
           .gsub("{{APP_NAME}}", @cfg.app_name)
           .gsub("{{YEAR}}", year.to_s)
       end
 
-      ACCESS_TOKEN_TEMPLATE = <<~HTML
+      ACTIVATION_TEMPLATE = <<~HTML
         <!DOCTYPE html>
         <html lang="ja">
         <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>{{APP_NAME}} — アクセストークン</title>
+        <title>{{APP_NAME}} — ご利用開始のご案内</title>
         </head>
         <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
         <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
@@ -103,18 +103,19 @@ module Infrastructure
         <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
         </td></tr>
         <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-        <h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">アクセストークンを発行しました</h1>
+        <h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
         <p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
         <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-        ご利用の <strong style="color:#4f46e5;">{{APP_NAME}}</strong> 向けにアクセストークンを発行しました。<br>
-        以下のトークンは第三者に共有せず、安全な場所で保管してください。
+        この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
+        下のボタンからご利用を開始してください。
         </p>
-        <p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">発行されたトークン</p>
-        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
-        <tr><td style="padding:16px 18px;word-break:break-all;">
-        <code style="font-family:monospace;font-size:13px;color:#111827;">{{TOKEN}}</code>
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+        <tr><td style="border-radius:6px;background-color:#4f46e5;">
+        <a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
         </td></tr>
         </table>
+        <p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
+        <p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
         <p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
         </td></tr>
         <tr><td align="center" style="padding:24px 16px 8px;">

--- a/backends/ruby-rails/app/usecase/client/interactor.rb
+++ b/backends/ruby-rails/app/usecase/client/interactor.rb
@@ -72,6 +72,7 @@ module UseCase
         Domain::Client::StoreResultVo.new(
           id:           saved.id,
           name:         saved.name,
+          identifier:   saved.identifier,
           email:        saved.email,
           access_token: saved.access_token,
         )

--- a/backends/rust-axum/Cargo.toml
+++ b/backends/rust-axum/Cargo.toml
@@ -35,3 +35,15 @@ percent-encoding = "2"
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
+
+# デバッグビルドでも RSA 鍵生成が実用的な速度になるよう暗号系クレートだけ最適化する。
+# cargo watch -x run (debug build) は rsa クレートが無最適化だと 4096bit 鍵生成に数十秒かかり
+# フロントエンドの 10 秒タイムアウトを超えてしまうため。
+[profile.dev.package.rsa]
+opt-level = 3
+[profile.dev.package.rand_core]
+opt-level = 3
+[profile.dev.package.rand]
+opt-level = 3
+[profile.dev.package.num-bigint-dig]
+opt-level = 3

--- a/backends/rust-axum/src/handler/client.rs
+++ b/backends/rust-axum/src/handler/client.rs
@@ -169,9 +169,9 @@ pub async fn store(
     let mailer = state.mailer.clone();
     let email = result.email.clone();
     let name = result.name.clone();
-    let token = result.token.clone();
+    let activate_url = format!("{}/clients/{}/qr", state.cfg.app.frontend_url, result.identifier);
     tokio::spawn(async move {
-        mailer.send_access_token(&email, &name, &token).await;
+        mailer.send_activation(&email, &name, &activate_url).await;
     });
 
     (StatusCode::CREATED, Json(json!({"id": result.id})))

--- a/backends/rust-axum/src/infrastructure/mail/mod.rs
+++ b/backends/rust-axum/src/infrastructure/mail/mod.rs
@@ -92,7 +92,7 @@ const ACTIVATION_TEMPLATE: &str = r#"<!DOCTYPE html>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{APP_NAME}} — ご利用開始のご案内</title>
 </head>
-<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans JP','Hiragino Sans','Hiragino Kaku Gothic ProN',Meiryo,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
 <tr><td align="center" style="padding:40px 16px;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px;margin:0 auto;">
@@ -100,20 +100,24 @@ const ACTIVATION_TEMPLATE: &str = r#"<!DOCTYPE html>
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
-<p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;line-height:1.4;letter-spacing:-0.02em;">ご利用開始のご案内</h1>
+<p style="margin:0 0 20px;font-size:14px;line-height:1.7;color:#6b7280;">{{NAME}} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
-下のボタンからご利用を開始してください。
+<strong style="color:#4f46e5;font-weight:600;">{{APP_NAME}}</strong> へのご登録が完了しました。<br>
+以下のボタンからご利用を開始してください。
 </p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
-<tr><td style="border-radius:6px;background-color:#4f46e5;">
-<a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+<tr><td align="center" style="padding:8px 0 24px;">
+<a href="{{ACTIVATE_URL}}" style="display:inline-block;background-color:#4f46e5;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.01em;">ご利用を開始する</a>
 </td></tr>
 </table>
-<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
-<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
-<p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
+<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">ボタンが開かない場合</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
+<tr><td style="padding:12px 16px;word-break:break-all;">
+<a href="{{ACTIVATE_URL}}" style="font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:12px;line-height:1.6;color:#4f46e5;text-decoration:none;">{{ACTIVATE_URL}}</a>
+</td></tr>
+</table>
+<p style="margin:20px 0 0;font-size:12px;line-height:1.65;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">
 <p style="margin:0;font-size:11px;color:#9ca3af;">© {{YEAR}} {{APP_NAME}}</p>

--- a/backends/rust-axum/src/infrastructure/mail/mod.rs
+++ b/backends/rust-axum/src/infrastructure/mail/mod.rs
@@ -19,13 +19,13 @@ impl Mailer {
         Self { cfg }
     }
 
-    pub async fn send_access_token(&self, to: &str, client_name: &str, token: &str) {
+    pub async fn send_activation(&self, to: &str, client_name: &str, activate_url: &str) {
         if to.is_empty() {
             return;
         }
 
-        let subject = mail_subject(&self.cfg.app_env, &format!("【{} / Rust】アクセストークンのお知らせ", self.cfg.app_name));
-        let body = build_access_token_html(client_name, token, &self.cfg.app_name);
+        let subject = mail_subject(&self.cfg.app_env, &format!("【{} / Rust】ご利用開始のご案内", self.cfg.app_name));
+        let body = build_activation_html(client_name, activate_url, &self.cfg.app_name);
 
         let from = format!("\"{}\" <{}>", self.cfg.app_name, self.cfg.from_address);
         let email = match Message::builder()
@@ -76,21 +76,21 @@ fn mail_subject(env: &str, subject: &str) -> String {
     }
 }
 
-fn build_access_token_html(name: &str, token: &str, app_name: &str) -> String {
+fn build_activation_html(name: &str, activate_url: &str, app_name: &str) -> String {
     let year = chrono::Local::now().year();
-    ACCESS_TOKEN_TEMPLATE
+    ACTIVATION_TEMPLATE
         .replace("{{NAME}}", name)
-        .replace("{{TOKEN}}", token)
+        .replace("{{ACTIVATE_URL}}", activate_url)
         .replace("{{APP_NAME}}", app_name)
         .replace("{{YEAR}}", &year.to_string())
 }
 
-const ACCESS_TOKEN_TEMPLATE: &str = r#"<!DOCTYPE html>
+const ACTIVATION_TEMPLATE: &str = r#"<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{APP_NAME}} — アクセストークン</title>
+<title>{{APP_NAME}} — ご利用開始のご案内</title>
 </head>
 <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
@@ -100,18 +100,19 @@ const ACCESS_TOKEN_TEMPLATE: &str = r#"<!DOCTYPE html>
 <span style="font-size:15px;font-weight:600;color:#1f2937;">{{APP_NAME}}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">アクセストークンを発行しました</h1>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
 <p style="margin:0 0 20px;font-size:14px;color:#6b7280;">{{NAME}} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-ご利用の <strong style="color:#4f46e5;">{{APP_NAME}}</strong> 向けにアクセストークンを発行しました。<br>
-以下のトークンは第三者に共有せず、安全な場所で保管してください。
+この度は <strong style="color:#4f46e5;">{{APP_NAME}}</strong> にご登録いただきありがとうございます。<br>
+下のボタンからご利用を開始してください。
 </p>
-<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">発行されたトークン</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
-<tr><td style="padding:16px 18px;word-break:break-all;">
-<code style="font-family:monospace;font-size:13px;color:#111827;">{{TOKEN}}</code>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+<tr><td style="border-radius:6px;background-color:#4f46e5;">
+<a href="{{ACTIVATE_URL}}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
 </td></tr>
 </table>
+<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
+<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">{{ACTIVATE_URL}}</p>
 <p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">

--- a/backends/rust-axum/src/infrastructure/mail/mod.rs
+++ b/backends/rust-axum/src/infrastructure/mail/mod.rs
@@ -39,9 +39,10 @@ impl Mailer {
             Err(e) => { error!("mail build error: {e}"); return; }
         };
 
-        let addr = format!("{}:{}", self.cfg.host, self.cfg.port);
+        let port: u16 = self.cfg.port.parse().unwrap_or(1025);
         let transport: AsyncSmtpTransport<Tokio1Executor> = if self.cfg.username.is_empty() {
-            AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&addr)
+            AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&self.cfg.host)
+                .port(port)
                 .build()
         } else {
             let creds = Credentials::new(self.cfg.username.clone(), self.cfg.password.clone());

--- a/backends/ts-hono/src/infrastructure/mail/mailer.ts
+++ b/backends/ts-hono/src/infrastructure/mail/mailer.ts
@@ -59,7 +59,7 @@ function buildHtml(name: string, activateUrl: string, appName: string): string {
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>${appName} — ご利用開始のご案内</title>
 </head>
-<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+<body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans JP','Hiragino Sans','Hiragino Kaku Gothic ProN',Meiryo,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
 <tr><td align="center" style="padding:40px 16px;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px;margin:0 auto;">
@@ -67,20 +67,24 @@ function buildHtml(name: string, activateUrl: string, appName: string): string {
 <span style="font-size:15px;font-weight:600;color:#1f2937;">${appName}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
-<p style="margin:0 0 20px;font-size:14px;color:#6b7280;">${name} 様</p>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;line-height:1.4;letter-spacing:-0.02em;">ご利用開始のご案内</h1>
+<p style="margin:0 0 20px;font-size:14px;line-height:1.7;color:#6b7280;">${name} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-この度は <strong style="color:#4f46e5;">${appName}</strong> にご登録いただきありがとうございます。<br>
-下のボタンからご利用を開始してください。
+<strong style="color:#4f46e5;font-weight:600;">${appName}</strong> へのご登録が完了しました。<br>
+以下のボタンからご利用を開始してください。
 </p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
-<tr><td style="border-radius:6px;background-color:#4f46e5;">
-<a href="${activateUrl}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+<tr><td align="center" style="padding:8px 0 24px;">
+<a href="${activateUrl}" style="display:inline-block;background-color:#4f46e5;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.01em;">ご利用を開始する</a>
 </td></tr>
 </table>
-<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
-<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">${activateUrl}</p>
-<p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
+<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">ボタンが開かない場合</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
+<tr><td style="padding:12px 16px;word-break:break-all;">
+<a href="${activateUrl}" style="font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:12px;line-height:1.6;color:#4f46e5;text-decoration:none;">${activateUrl}</a>
+</td></tr>
+</table>
+<p style="margin:20px 0 0;font-size:12px;line-height:1.65;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">
 <p style="margin:0;font-size:11px;color:#9ca3af;">© ${year} ${appName}</p>

--- a/backends/ts-hono/src/infrastructure/mail/mailer.ts
+++ b/backends/ts-hono/src/infrastructure/mail/mailer.ts
@@ -19,17 +19,17 @@ function mailSubject(subject: string): string {
 }
 
 /**
- * クライアントのアクセストークンをメール送信します。
+ * クライアントにご利用開始のご案内をメール送信します。
  * @param to - 送信先メールアドレス
  * @param clientName - クライアント名
- * @param token - アクセストークン
+ * @param activateUrl - QRページURL
  */
-export async function sendAccessToken(to: string, clientName: string, token: string): Promise<void> {
+export async function sendActivation(to: string, clientName: string, activateUrl: string): Promise<void> {
   if (!to) return;
 
   const { host, port, username, password, fromAddress, appName } = config.mail;
-  const subject = mailSubject(`【${appName} / TypeScript】アクセストークンのお知らせ`);
-  const html = buildHtml(clientName, token, appName);
+  const subject = mailSubject(`【${appName} / TypeScript】ご利用開始のご案内`);
+  const html = buildHtml(clientName, activateUrl, appName);
 
   const transporter = nodemailer.createTransport({
     host,
@@ -50,14 +50,14 @@ export async function sendAccessToken(to: string, clientName: string, token: str
   }
 }
 
-function buildHtml(name: string, token: string, appName: string): string {
+function buildHtml(name: string, activateUrl: string, appName: string): string {
   const year = new Date().getFullYear();
   return `<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>${appName} — アクセストークン</title>
+<title>${appName} — ご利用開始のご案内</title>
 </head>
 <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f9fafb;">
@@ -67,18 +67,19 @@ function buildHtml(name: string, token: string, appName: string): string {
 <span style="font-size:15px;font-weight:600;color:#1f2937;">${appName}</span>
 </td></tr>
 <tr><td style="background-color:#ffffff;border:1px solid #e5e7eb;border-top:1px solid #f3f4f6;padding:28px 24px 32px;border-radius:0 0 12px 12px;">
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">アクセストークンを発行しました</h1>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600;color:#111827;">ご利用開始のご案内</h1>
 <p style="margin:0 0 20px;font-size:14px;color:#6b7280;">${name} 様</p>
 <p style="margin:0 0 24px;font-size:14px;line-height:1.75;color:#374151;">
-ご利用の <strong style="color:#4f46e5;">${appName}</strong> 向けにアクセストークンを発行しました。<br>
-以下のトークンは第三者に共有せず、安全な場所で保管してください。
+この度は <strong style="color:#4f46e5;">${appName}</strong> にご登録いただきありがとうございます。<br>
+下のボタンからご利用を開始してください。
 </p>
-<p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.06em;">発行されたトークン</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f3f4f6;border:1px solid #e5e7eb;border-radius:8px;">
-<tr><td style="padding:16px 18px;word-break:break-all;">
-<code style="font-family:monospace;font-size:13px;color:#111827;">${token}</code>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+<tr><td style="border-radius:6px;background-color:#4f46e5;">
+<a href="${activateUrl}" target="_blank" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">ご利用を開始する</a>
 </td></tr>
 </table>
+<p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが機能しない場合は以下の URL をブラウザに貼り付けてください。</p>
+<p style="margin:0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">${activateUrl}</p>
 <p style="margin:20px 0 0;font-size:12px;color:#9ca3af;">このメールに心当たりがない場合は、管理者までご連絡ください。</p>
 </td></tr>
 <tr><td align="center" style="padding:24px 16px 8px;">

--- a/backends/ts-hono/src/routes/clients.ts
+++ b/backends/ts-hono/src/routes/clients.ts
@@ -4,6 +4,7 @@
  * @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
  */
 import { Hono } from "hono";
+import { config } from "../config.js";
 import { formatTime, getStaffIdFromCookie } from "../lib/cookie.js";
 import { badRequest } from "../lib/errors.js";
 import { db, asTx } from "../db/client.js";
@@ -13,7 +14,7 @@ import { DrizzleNotificationRepository } from "../infrastructure/persistence/dri
 import { DrizzleStaffRepository } from "../infrastructure/persistence/drizzleStaffRepository.js";
 import { ClientInteractor } from "../usecase/client/interactor.js";
 import { NotificationInteractor } from "../usecase/notification/interactor.js";
-import { sendAccessToken } from "../infrastructure/mail/mailer.js";
+import { sendActivation } from "../infrastructure/mail/mailer.js";
 import type { ClientListItem, ClientDetailVo } from "../domain/client/valueObjects.js";
 
 function formatTimeSec(d: Date | null | undefined): string | null {
@@ -89,7 +90,8 @@ app.post("/clients/store", async (c) => {
   const notifUrl = `/clients/show?id=${result.id}`;
   const notifUc = new NotificationInteractor(new DrizzleNotificationRepository(db), new DrizzleStaffRepository(db));
   notifUc.fanOut("新しいクライアントが登録されました", result.name, notifUrl, executorId, 1).catch(err => console.error("[fanOut]", err));
-  sendAccessToken(result.email, result.name, result.token).catch(err => console.error("[sendAccessToken]", err));
+  const activateUrl = `${config.app.frontendUrl}/clients/${result.identifier}/qr`;
+  sendActivation(result.email, result.name, activateUrl).catch(err => console.error("[sendActivation]", err));
 
   return c.json({ id: result.id, name: result.name, identifier: result.identifier, email: result.email, token: result.token }, 201);
 });


### PR DESCRIPTION
## Summary

- **feat(#67)**: クライアント登録通知メールをアクセストークン直接記載からQRページURL案内に刷新（全9バックエンド展開）
- **feat(#18)**: JWT履歴機能の全バックエンド展開・フロント実API接続
- **fix**: Ruby(Rails/Hanami) soft_delete のアトミック化・クライアント削除時のステータス Closed 更新
- **fix**: Rust クライアント削除ルート修正（`/clients/{id}/delete`）
- **fix**: UI フロー図のレイアウト調整

## Test plan

- [ ] CI 全バックエンド グリーン確認済み
- [ ] PHP Laravel でクライアント登録 → 「ご利用開始のご案内」メール受信確認済み
- [ ] Ruby Rails でクライアント登録 → 新メール送信確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated client activation flow: clients now receive activation emails with direct clickable links instead of access tokens for faster service onboarding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bobtabo/authorization/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->