### PR TITLE
feat(#87): スタッフ一覧サーバーサイドページング実装 (PHP Laravel)

### DIFF
--- a/backends/php-laravel/app/Domain/Staff/Repositories/StaffRepository.php
+++ b/backends/php-laravel/app/Domain/Staff/Repositories/StaffRepository.php
@@ -31,6 +31,14 @@ interface StaffRepository
     public function findByCondition(StaffCondition $condition): Collection;
 
     /**
+     * 条件でスタッフ件数を取得します。
+     *
+     * @param StaffCondition $condition 検索条件
+     * @return int 件数
+     */
+    public function countByCondition(StaffCondition $condition): int;
+
+    /**
      * ID でスタッフを取得します。
      *
      * @param StaffCondition $condition 検索条件（id を設定すること）

--- a/backends/php-laravel/app/Domain/Staff/ValueObjects/StaffListVo.php
+++ b/backends/php-laravel/app/Domain/Staff/ValueObjects/StaffListVo.php
@@ -12,6 +12,7 @@ namespace App\Domain\Staff\ValueObjects;
 
 use App\Domain\Staff\Entities\Staff;
 use App\Domain\Staff\Mappers\StaffApiMapper;
+use App\Support\Enums\SortType;
 use App\Support\Traits\Getter;
 use App\Support\ValueObjects\AbstractValueObject;
 use Illuminate\Support\Collection;
@@ -26,10 +27,12 @@ class StaffListVo extends AbstractValueObject
 {
     use Getter;
 
-    /**
-     * 一覧行（{@see StaffResourceVo}）のコレクションです。
-     */
     protected Collection $items;
+    private int $count = 0;
+    private int $offset = 0;
+    private int $limit = 0;
+    private string $sort = '';
+    private SortType $sortType = SortType::NONE;
 
     /**
      * スタッフ Entity のリストを一覧行に設定します。
@@ -47,9 +50,35 @@ class StaffListVo extends AbstractValueObject
     }
 
     /**
+     * 総件数を設定します。
+     *
+     * @param int $count 総件数
+     */
+    public function setCount(int $count): void
+    {
+        $this->count = $count;
+    }
+
+    /**
+     * ページング情報を設定します。
+     *
+     * @param int $offset オフセット
+     * @param int $limit 取得件数
+     * @param string $sort ソート対象
+     * @param SortType $sortType ソート順
+     */
+    public function setPaging(int $offset, int $limit, string $sort, SortType $sortType): void
+    {
+        $this->offset = $offset;
+        $this->limit = $limit;
+        $this->sort = $sort;
+        $this->sortType = $sortType;
+    }
+
+    /**
      * {@inheritdoc}
      *
-     * @return array{items: list<array<string, mixed>>}
+     * @return array<string, mixed>
      */
     #[\Override]
     public function attributes(): array
@@ -59,6 +88,11 @@ class StaffListVo extends AbstractValueObject
                 ->map(static fn (StaffResourceVo $row): array => $row->attributes())
                 ->values()
                 ->all(),
+            'count' => $this->count,
+            'offset' => $this->offset,
+            'limit' => $this->limit,
+            'sort' => $this->sort,
+            'sortType' => $this->sortType,
         ];
     }
 }

--- a/backends/php-laravel/app/Http/Controllers/Api/StaffController.php
+++ b/backends/php-laravel/app/Http/Controllers/Api/StaffController.php
@@ -38,16 +38,8 @@ class StaffController extends Controller
      */
     public function index(AppRequest $request, StaffService $service): JsonResponse
     {
-        $keyword = $request->query('keyword');
-        $keyword = is_string($keyword) && $keyword !== '' ? $keyword : null;
-
-        $roles = $this->intListFromQuery($request->query('roles'));
-        $statuses = $this->intListFromQuery($request->query('statuses'));
-
         $dto = new StaffDto();
-        $dto->keyword = $keyword;
-        $dto->roles = $roles;
-        $dto->statuses = $statuses;
+        $dto->assign($request->input());
 
         $vo = $service->index($dto);
 
@@ -114,26 +106,4 @@ class StaffController extends Controller
         return response()->success(['id' => $vo->getId()]);
     }
 
-    /**
-     * クエリの単一値または配列を int のリストにします。
-     *
-     * @param array<int|string>|string|int|null $raw
-     * @return array<int, int>
-     */
-    private function intListFromQuery(array|string|int|null $raw): array
-    {
-        if ($raw === null || $raw === '' || $raw === []) {
-            return [];
-        }
-        $list = is_array($raw) ? $raw : [$raw];
-        $out = [];
-        foreach ($list as $v) {
-            if ($v === '' || $v === null) {
-                continue;
-            }
-            $out[] = (int)$v;
-        }
-
-        return $out;
-    }
 }

--- a/backends/php-laravel/app/Http/Responses/Staff/StaffIndexResponse.php
+++ b/backends/php-laravel/app/Http/Responses/Staff/StaffIndexResponse.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace App\Http\Responses\Staff;
 
 use App\Support\Http\Responses\AbstractResponse;
+use App\Support\Http\Responses\Traits\Pager;
 use App\Support\Traits\Getter;
 
 /**
@@ -22,6 +23,26 @@ use App\Support\Traits\Getter;
 class StaffIndexResponse extends AbstractResponse
 {
     use Getter;
+    use Pager;
 
-    private array $items = [];
+    /**
+     * @var list<array<string, mixed>>
+     */
+    public array $items = [];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return array{data: list<array<string, mixed>>, pager: mixed}
+     */
+    #[\Override]
+    public function attributes(): array
+    {
+        $pager = $this->createPager(count($this->items));
+
+        return [
+            'data' => $this->items,
+            'pager' => $pager,
+        ];
+    }
 }

--- a/backends/php-laravel/app/Http/Responses/Staff/StaffIndexResponse.php
+++ b/backends/php-laravel/app/Http/Responses/Staff/StaffIndexResponse.php
@@ -32,8 +32,6 @@ class StaffIndexResponse extends AbstractResponse
 
     /**
      * {@inheritdoc}
-     *
-     * @return array{data: list<array<string, mixed>>, pager: mixed}
      */
     #[\Override]
     public function attributes(): array

--- a/backends/php-laravel/app/Infrastructure/Persistence/EloquentStaffRepository.php
+++ b/backends/php-laravel/app/Infrastructure/Persistence/EloquentStaffRepository.php
@@ -15,6 +15,7 @@ use App\Domain\Staff\Entities\Staff as Entity;
 use App\Domain\Staff\Repositories\StaffRepository;
 use App\Infrastructure\Models\Staff as Model;
 use App\Support\Repositories\AbstractEloquentRepository;
+use App\Support\Repositories\Traits\OptionBuilder;
 use Illuminate\Support\Collection;
 
 /**
@@ -25,6 +26,8 @@ use Illuminate\Support\Collection;
  */
 class EloquentStaffRepository extends AbstractEloquentRepository implements StaffRepository
 {
+    use OptionBuilder;
+
     /**
      * {@inheritdoc}
      */
@@ -34,6 +37,37 @@ class EloquentStaffRepository extends AbstractEloquentRepository implements Staf
         $query = Model::withTrashed()->newQuery()
             ->select('staffs.*');
 
+        $this->applyFilters($query, $condition);
+
+        if ($condition->isPaging()) {
+            $query = $this->addOption($query, $condition->option);
+        }
+
+        return $this->findByQuery($query);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[\Override]
+    public function countByCondition(StaffCondition $condition): int
+    {
+        $query = Model::withTrashed()->newQuery()
+            ->select('staffs.*');
+
+        $this->applyFilters($query, $condition);
+
+        return $query->count();
+    }
+
+    /**
+     * 検索フィルタをクエリに適用します。
+     *
+     * @param \Illuminate\Contracts\Database\Eloquent\Builder $query クエリ
+     * @param StaffCondition $condition 検索条件
+     */
+    private function applyFilters($query, StaffCondition $condition): void
+    {
         if (!empty($condition->keyword)) {
             $keyword = str($condition->keyword)->trim()->replace(' ', '')->value();
             $query->where(function ($subQuery) use ($keyword) {
@@ -43,14 +77,12 @@ class EloquentStaffRepository extends AbstractEloquentRepository implements Staf
         }
 
         if (!empty($condition->roles)) {
-            $query->whereIn('clients.role', $condition->roles);
+            $query->whereIn('staffs.role', $condition->roles);
         }
 
         if (!empty($condition->statuses)) {
-            $query->whereIn('clients.status', $condition->statuses);
+            $query->whereIn('staffs.status', $condition->statuses);
         }
-
-        return $this->findByQuery($query);
     }
 
     /**

--- a/backends/php-laravel/app/UseCases/Staff/Dtos/StaffDto.php
+++ b/backends/php-laravel/app/UseCases/Staff/Dtos/StaffDto.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace App\UseCases\Staff\Dtos;
 
 use App\Domain\Staff\Enums\StaffRole;
-use App\Support\Dtos\AbstractDto;
+use App\Support\Dtos\PagerDto;
 
 /**
  * スタッフ API 用の入力 DTO です（一覧・権限更新・削除・単体取得で共用します）。
@@ -19,7 +19,7 @@ use App\Support\Dtos\AbstractDto;
  * @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
  * @package App\UseCases\Staff\Dtos
  */
-class StaffDto extends AbstractDto
+class StaffDto extends PagerDto
 {
     public ?int $id = null;
 

--- a/backends/php-laravel/app/UseCases/Staff/StaffService.php
+++ b/backends/php-laravel/app/UseCases/Staff/StaffService.php
@@ -20,6 +20,7 @@ use App\Domain\Staff\ValueObjects\StaffRemoveVo;
 use App\Domain\Staff\ValueObjects\StaffResourceVo;
 use App\Support\Exceptions\AppException;
 use App\Support\Mappers\SimpleMapper;
+use App\Support\Repositories\Conditions\Option;
 use App\Support\Services\AbstractService;
 use App\UseCases\Staff\Dtos\StaffDto;
 use Illuminate\Database\QueryException;
@@ -80,11 +81,15 @@ class StaffService extends AbstractService
         $condition->keyword = $dto->keyword;
         $condition->roles = $dto->roles;
         $condition->statuses = $dto->statuses;
+        $condition->option = new Option($dto->offset, $dto->limit, $dto->sort, $dto->sortType);
 
+        $count = $this->repository->countByCondition($condition);
         $list = $this->repository->findByCondition($condition);
 
         $vo = new StaffListVo();
         $vo->assignStaff($list);
+        $vo->setCount($count);
+        $vo->setPaging($dto->offset, $dto->limit, $dto->sort, $dto->sortType);
 
         return $vo;
     }


### PR DESCRIPTION
## 概要

Issue #87・#105 の設計に従い、`GET /api/staffs` にサーバーサイドページングを実装する。

## 変更内容

### `StaffDto`
- `AbstractDto` → `PagerDto` に変更
- `assign()` 時に `setPaging()` が自動呼び出しされ `offset` を内部算出

### `StaffController::index()`
- 手動の keyword/roles/statuses パース処理を削除
- `$dto->assign($request->input())` に統一
- 不要になった `intListFromQuery()` を削除

### `StaffService::index()`
- `countByCondition()` で総件数を取得
- `Option` を生成して Condition に設定
- `StaffListVo` に件数・ページング情報をセット

### `StaffListVo`
- `count`・`offset`・`limit`・`sort`・`sortType` フィールドを追加
- `setCount()` / `setPaging()` メソッドを追加
- `attributes()` にページング情報を含める

### `StaffIndexResponse`
- `Pager` トレイトを追加
- `attributes()` を `{ data, pager }` 形式に変更

### `StaffRepository` インターフェース
- `countByCondition()` を追加

### `EloquentStaffRepository`
- `OptionBuilder` トレイトを追加
- `countByCondition()` を実装
- フィルタ処理を `applyFilters()` に切り出し
- バグ修正：`clients.role` / `clients.status` → `staffs.role` / `staffs.status`

## 関連

- Issue #87
- Issue #105（ページング API 設計）
- Issue #108（実装修正方針）