### PR TITLE
feat(#87): 全バックエンドのスタッフ一覧にサーバーサイドページング実装

### DIFF
--- a/backends/go-beego/internal/domain/staff/condition.go
+++ b/backends/go-beego/internal/domain/staff/condition.go
@@ -1,6 +1,10 @@
 package staff
 
 type Condition struct {
-	Keyword *string
-	Roles   []int
+	Keyword  *string
+	Roles    []int
+	Offset   int
+	Limit    int
+	Sort     string
+	SortType string
 }

--- a/backends/go-beego/internal/domain/staff/repository.go
+++ b/backends/go-beego/internal/domain/staff/repository.go
@@ -3,6 +3,8 @@ package staff
 
 // Repository はスタッフの永続化インターフェースです。
 type Repository interface {
+	// CountByCondition は条件に合うスタッフの総件数を返します。
+	CountByCondition(cond Condition) (int, error)
 	// FindByCondition は条件に合うスタッフ一覧を取得します。
 	FindByCondition(cond Condition) ([]*Staff, error)
 	// FindByID はIDでスタッフを取得します。

--- a/backends/go-beego/internal/handler/staff_handler.go
+++ b/backends/go-beego/internal/handler/staff_handler.go
@@ -32,12 +32,41 @@ func (h *StaffHandler) Index(ctx *beecontext.Context) {
 	}
 	cond.Roles = parseIntList(ctx.Request.URL.Query()["roles"])
 
-	staffs, err := h.newStaffUC(h.ormer).FindByCondition(cond)
+	limit := 20
+	if v := ctx.Input.Query("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	page := 1
+	if v := ctx.Input.Query("page"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			page = n
+		}
+	}
+	offset := limit * (page - 1)
+	cond.Offset = offset
+	cond.Limit = limit
+	cond.Sort = ctx.Input.Query("sort")
+	cond.SortType = ctx.Input.Query("sort_type")
+
+	uc := h.newStaffUC(h.ormer)
+	count, err := uc.CountByCondition(cond)
 	if err != nil {
 		writeError(ctx, err)
 		return
 	}
-	writeJSON(ctx, http.StatusOK, map[string]interface{}{"items": mapStaffList(staffs)})
+	staffs, err := uc.FindByCondition(cond)
+	if err != nil {
+		writeError(ctx, err)
+		return
+	}
+
+	pager := BuildPager(count, limit, offset, len(staffs))
+	writeJSON(ctx, http.StatusOK, map[string]interface{}{
+		"data":  mapStaffList(staffs),
+		"pager": pager,
+	})
 }
 
 func (h *StaffHandler) UpdateRole(ctx *beecontext.Context) {

--- a/backends/go-beego/internal/infrastructure/persistence/gorm_staff_repository.go
+++ b/backends/go-beego/internal/infrastructure/persistence/gorm_staff_repository.go
@@ -18,16 +18,32 @@ func NewOrmStaffRepository(o QueryOrmer) *OrmStaffRepository {
 	return &OrmStaffRepository{o: o}
 }
 
+func (r *OrmStaffRepository) CountByCondition(cond domstaff.Condition) (int, error) {
+	qs := r.o.QueryTable(new(model.Staff))
+	qs = r.applyFilters(qs, cond)
+	count, err := qs.Count()
+	return int(count), err
+}
+
 func (r *OrmStaffRepository) FindByCondition(cond domstaff.Condition) ([]*domstaff.Staff, error) {
-	qs := r.o.QueryTable(new(model.Staff)).OrderBy("id")
-	if cond.Keyword != nil && *cond.Keyword != "" {
-		kw := *cond.Keyword
-		kwCond := orm.NewCondition().And("name__contains", kw).Or("email__contains", kw)
-		qs = qs.SetCond(kwCond)
+	qs := r.o.QueryTable(new(model.Staff))
+	qs = r.applyFilters(qs, cond)
+
+	if cond.Limit > 0 {
+		qs = qs.Limit(cond.Limit, cond.Offset)
 	}
-	if len(cond.Roles) > 0 {
-		qs = qs.Filter("role__in", cond.Roles)
+
+	allowedSort := map[string]bool{"name": true, "role": true, "status": true, "created_at": true}
+	sort := "id"
+	if cond.Sort != "" && allowedSort[cond.Sort] {
+		sort = cond.Sort
 	}
+	if cond.SortType == "desc" {
+		qs = qs.OrderBy("-" + sort)
+	} else {
+		qs = qs.OrderBy(sort)
+	}
+
 	var ms []*model.Staff
 	if _, err := qs.All(&ms); err != nil {
 		return nil, err
@@ -37,6 +53,18 @@ func (r *OrmStaffRepository) FindByCondition(cond domstaff.Condition) ([]*domsta
 		out = append(out, staffToDomain(m))
 	}
 	return out, nil
+}
+
+func (r *OrmStaffRepository) applyFilters(qs orm.QuerySeter, cond domstaff.Condition) orm.QuerySeter {
+	if cond.Keyword != nil && *cond.Keyword != "" {
+		kw := *cond.Keyword
+		kwCond := orm.NewCondition().And("name__contains", kw).Or("email__contains", kw)
+		qs = qs.SetCond(kwCond)
+	}
+	if len(cond.Roles) > 0 {
+		qs = qs.Filter("role__in", cond.Roles)
+	}
+	return qs
 }
 
 func (r *OrmStaffRepository) FindByID(s *domstaff.Staff) (*domstaff.Staff, error) {

--- a/backends/go-beego/internal/usecase/staff/interactor.go
+++ b/backends/go-beego/internal/usecase/staff/interactor.go
@@ -16,6 +16,11 @@ func NewInteractor(repo domstaff.Repository) *Interactor {
 	return &Interactor{repo: repo}
 }
 
+// CountByCondition は条件に合うスタッフの総件数を返します。
+func (uc *Interactor) CountByCondition(cond domstaff.Condition) (int, error) {
+	return uc.repo.CountByCondition(cond)
+}
+
 // FindByCondition は条件に合うスタッフ一覧を取得します。
 func (uc *Interactor) FindByCondition(cond domstaff.Condition) ([]*domstaff.ListItem, error) {
 	staffs, err := uc.repo.FindByCondition(cond)

--- a/backends/go-beego/tests/client_test.go
+++ b/backends/go-beego/tests/client_test.go
@@ -283,10 +283,11 @@ func TestClient_SoftDelete(t *testing.T) {
 		if w.Code != http.StatusOK {
 			t.Errorf("want 200, got %d", w.Code)
 		}
-		var list []map[string]interface{}
-		json.Unmarshal(w.Body.Bytes(), &list)
-		if len(list) != 1 {
-			t.Errorf("want 1 item (including soft-deleted), got %d", len(list))
+		var response map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &response)
+		data := response["data"].([]interface{})
+		if len(data) != 1 {
+			t.Errorf("want 1 item (including soft-deleted), got %d", len(data))
 		}
 	})
 

--- a/backends/go-beego/tests/staff_test.go
+++ b/backends/go-beego/tests/staff_test.go
@@ -17,8 +17,11 @@ func TestStaff_Index(t *testing.T) {
 			t.Errorf("want 200, got %d: %s", w.Code, w.Body.String())
 		}
 		body := parseBody(w)
-		if body["items"] == nil {
-			t.Error("items not found in response")
+		if body["data"] == nil {
+			t.Error("data not found in response")
+		}
+		if body["pager"] == nil {
+			t.Error("pager not found in response")
 		}
 	})
 
@@ -29,9 +32,9 @@ func TestStaff_Index(t *testing.T) {
 			t.Errorf("want 200, got %d", w.Code)
 		}
 		body := parseBody(w)
-		items, ok := body["items"].([]interface{})
-		if !ok || len(items) != 0 {
-			t.Errorf("want empty items, got %v", body["items"])
+		data, ok := body["data"].([]interface{})
+		if !ok || len(data) != 0 {
+			t.Errorf("want empty data, got %v", body["data"])
 		}
 	})
 }

--- a/backends/go-echo/internal/domain/staff/condition.go
+++ b/backends/go-echo/internal/domain/staff/condition.go
@@ -1,6 +1,10 @@
 package staff
 
 type Condition struct {
-	Keyword *string
-	Roles   []int
+	Keyword  *string
+	Roles    []int
+	Offset   int
+	Limit    int
+	Sort     string
+	SortType string
 }

--- a/backends/go-echo/internal/domain/staff/repository.go
+++ b/backends/go-echo/internal/domain/staff/repository.go
@@ -3,6 +3,8 @@ package staff
 
 // Repository はスタッフの永続化インターフェースです。
 type Repository interface {
+	// CountByCondition は条件に合うスタッフの総件数を返します。
+	CountByCondition(cond Condition) (int, error)
 	// FindByCondition は条件に合うスタッフ一覧を取得します。
 	FindByCondition(cond Condition) ([]*Staff, error)
 	// FindByID はIDでスタッフを取得します（論理削除済みは除外）。

--- a/backends/go-echo/internal/handler/staff_handler.go
+++ b/backends/go-echo/internal/handler/staff_handler.go
@@ -27,11 +27,40 @@ func (h *StaffHandler) Index(c echo.Context) error {
 		cond.Keyword = &kw
 	}
 	cond.Roles = parseIntList(c.QueryParams()["roles"])
-	staffs, err := h.newStaffUC(h.db).FindByCondition(cond)
+
+	limit := 20
+	if v := c.QueryParam("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	page := 1
+	if v := c.QueryParam("page"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			page = n
+		}
+	}
+	offset := limit * (page - 1)
+	cond.Offset = offset
+	cond.Limit = limit
+	cond.Sort = c.QueryParam("sort")
+	cond.SortType = c.QueryParam("sort_type")
+
+	uc := h.newStaffUC(h.db)
+	count, err := uc.CountByCondition(cond)
 	if err != nil {
 		return err
 	}
-	return c.JSON(http.StatusOK, map[string]interface{}{"items": mapStaffList(staffs)})
+	staffs, err := uc.FindByCondition(cond)
+	if err != nil {
+		return err
+	}
+
+	pager := BuildPager(count, limit, offset, len(staffs))
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"data":  mapStaffList(staffs),
+		"pager": pager,
+	})
 }
 
 func (h *StaffHandler) UpdateRole(c echo.Context) error {

--- a/backends/go-echo/internal/infrastructure/persistence/ent_staff_repository.go
+++ b/backends/go-echo/internal/infrastructure/persistence/ent_staff_repository.go
@@ -17,15 +17,35 @@ func NewEntStaffRepository(db *ent.Client) *EntStaffRepository {
 	return &EntStaffRepository{db: db}
 }
 
+func (r *EntStaffRepository) CountByCondition(cond domstaff.Condition) (int, error) {
+	q := r.db.Staff.Query()
+	q = r.applyFilters(q, cond)
+	return q.Count(context.Background())
+}
+
 func (r *EntStaffRepository) FindByCondition(cond domstaff.Condition) ([]*domstaff.Staff, error) {
-	q := r.db.Staff.Query().Order(ent.Asc(staff.FieldID))
-	if cond.Keyword != nil && *cond.Keyword != "" {
-		like := *cond.Keyword
-		q = q.Where(staff.Or(staff.NameContains(like), staff.EmailContains(like)))
+	q := r.db.Staff.Query()
+	q = r.applyFilters(q, cond)
+
+	if cond.Limit > 0 {
+		q = q.Limit(cond.Limit).Offset(cond.Offset)
 	}
-	if len(cond.Roles) > 0 {
-		q = q.Where(staff.RoleIn(cond.Roles...))
+
+	allowedSort := map[string]string{
+		"name":       staff.FieldName,
+		"role":       staff.FieldRole,
+		"created_at": staff.FieldCreatedAt,
 	}
+	sortField := staff.FieldID
+	if f, ok := allowedSort[cond.Sort]; ok {
+		sortField = f
+	}
+	if cond.SortType == "desc" {
+		q = q.Order(ent.Desc(sortField))
+	} else {
+		q = q.Order(ent.Asc(sortField))
+	}
+
 	ms, err := q.All(context.Background())
 	if err != nil {
 		return nil, err
@@ -35,6 +55,17 @@ func (r *EntStaffRepository) FindByCondition(cond domstaff.Condition) ([]*domsta
 		out = append(out, entStaffToDomain(m))
 	}
 	return out, nil
+}
+
+func (r *EntStaffRepository) applyFilters(q *ent.StaffQuery, cond domstaff.Condition) *ent.StaffQuery {
+	if cond.Keyword != nil && *cond.Keyword != "" {
+		like := *cond.Keyword
+		q = q.Where(staff.Or(staff.NameContains(like), staff.EmailContains(like)))
+	}
+	if len(cond.Roles) > 0 {
+		q = q.Where(staff.RoleIn(cond.Roles...))
+	}
+	return q
 }
 
 func (r *EntStaffRepository) FindByID(s *domstaff.Staff) (*domstaff.Staff, error) {

--- a/backends/go-echo/internal/usecase/staff/interactor.go
+++ b/backends/go-echo/internal/usecase/staff/interactor.go
@@ -16,6 +16,11 @@ func NewInteractor(repo domstaff.Repository) *Interactor {
 	return &Interactor{repo: repo}
 }
 
+// CountByCondition は条件に合うスタッフの総件数を返します。
+func (uc *Interactor) CountByCondition(cond domstaff.Condition) (int, error) {
+	return uc.repo.CountByCondition(cond)
+}
+
 // FindByCondition は条件に合うスタッフ一覧を取得します。
 func (uc *Interactor) FindByCondition(cond domstaff.Condition) ([]*domstaff.ListItem, error) {
 	staffs, err := uc.repo.FindByCondition(cond)

--- a/backends/go-echo/tests/client_test.go
+++ b/backends/go-echo/tests/client_test.go
@@ -313,10 +313,11 @@ func TestClient_SoftDelete(t *testing.T) {
 		if w.Code != http.StatusOK {
 			t.Errorf("want 200, got %d", w.Code)
 		}
-		var list []map[string]interface{}
-		json.Unmarshal(w.Body.Bytes(), &list)
-		if len(list) != 1 {
-			t.Errorf("want 1 item (including soft-deleted), got %d", len(list))
+		var response map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &response)
+		data := response["data"].([]interface{})
+		if len(data) != 1 {
+			t.Errorf("want 1 item (including soft-deleted), got %d", len(data))
 		}
 	})
 

--- a/backends/go-echo/tests/staff_test.go
+++ b/backends/go-echo/tests/staff_test.go
@@ -17,8 +17,11 @@ func TestStaff_Index(t *testing.T) {
 			t.Errorf("want 200, got %d: %s", w.Code, w.Body.String())
 		}
 		body := parseBody(w)
-		if body["items"] == nil {
-			t.Error("items not found in response")
+		if body["data"] == nil {
+			t.Error("data not found in response")
+		}
+		if body["pager"] == nil {
+			t.Error("pager not found in response")
 		}
 	})
 
@@ -29,9 +32,9 @@ func TestStaff_Index(t *testing.T) {
 			t.Errorf("want 200, got %d", w.Code)
 		}
 		body := parseBody(w)
-		items, ok := body["items"].([]interface{})
-		if !ok || len(items) != 0 {
-			t.Errorf("want empty items, got %v", body["items"])
+		data, ok := body["data"].([]interface{})
+		if !ok || len(data) != 0 {
+			t.Errorf("want empty data, got %v", body["data"])
 		}
 	})
 }

--- a/backends/go-gin/internal/domain/staff/condition.go
+++ b/backends/go-gin/internal/domain/staff/condition.go
@@ -2,6 +2,10 @@ package staff
 
 // Condition はスタッフ検索条件です。
 type Condition struct {
-	Keyword *string
-	Roles   []int
+	Keyword  *string
+	Roles    []int
+	Offset   int
+	Limit    int
+	Sort     string
+	SortType string
 }

--- a/backends/go-gin/internal/domain/staff/repository.go
+++ b/backends/go-gin/internal/domain/staff/repository.go
@@ -2,6 +2,8 @@ package staff
 
 // Repository はスタッフの永続化インターフェースです。
 type Repository interface {
+	// CountByCondition は検索条件に合致するスタッフの総件数を返します。
+	CountByCondition(cond Condition) (int, error)
 	// FindByCondition は検索条件に合致するスタッフエンティティを返します。
 	FindByCondition(cond Condition) ([]*Staff, error)
 	// FindByID はIDでスタッフエンティティを返します。存在しない場合は nil を返します。

--- a/backends/go-gin/internal/handler/staff_handler.go
+++ b/backends/go-gin/internal/handler/staff_handler.go
@@ -36,12 +36,41 @@ func (h *StaffHandler) Index(c *gin.Context) {
 	}
 	cond.Roles = parseIntList(c.QueryArray("roles"))
 
-	staffs, err := h.newStaffUC(h.db).FindByCondition(cond)
+	limit := 20
+	if v := c.Query("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	page := 1
+	if v := c.Query("page"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			page = n
+		}
+	}
+	offset := limit * (page - 1)
+	cond.Offset = offset
+	cond.Limit = limit
+	cond.Sort = c.Query("sort")
+	cond.SortType = c.Query("sort_type")
+
+	uc := h.newStaffUC(h.db)
+	count, err := uc.CountByCondition(cond)
 	if err != nil {
 		_ = c.Error(err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"items": mapStaffList(staffs)})
+	staffs, err := uc.FindByCondition(cond)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	pager := BuildPager(count, limit, offset, len(staffs))
+	c.JSON(http.StatusOK, gin.H{
+		"data":  mapStaffList(staffs),
+		"pager": pager,
+	})
 }
 
 // UpdateRole はスタッフの権限を更新します。

--- a/backends/go-gin/internal/infrastructure/persistence/gorm_staff_repository.go
+++ b/backends/go-gin/internal/infrastructure/persistence/gorm_staff_repository.go
@@ -23,16 +23,37 @@ func NewGormStaffRepository(db *gorm.DB) *GormStaffRepository {
 	return &GormStaffRepository{db: db}
 }
 
+// CountByCondition は検索条件に合致するスタッフの総件数を返します。
+func (r *GormStaffRepository) CountByCondition(cond domstaff.Condition) (int, error) {
+	var count int64
+	q := r.db.Model(&model.Staff{}).Unscoped()
+	q = r.applyFilters(q, cond)
+	if err := q.Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return int(count), nil
+}
+
 // FindByCondition は検索条件に合致するスタッフエンティティを返します。
 func (r *GormStaffRepository) FindByCondition(cond domstaff.Condition) ([]*domstaff.Staff, error) {
-	q := r.db.Unscoped().Order("id ASC")
-	if cond.Keyword != nil && *cond.Keyword != "" {
-		like := "%" + *cond.Keyword + "%"
-		q = q.Where("name LIKE ? OR email LIKE ?", like, like)
+	q := r.db.Unscoped()
+	q = r.applyFilters(q, cond)
+
+	if cond.Limit > 0 {
+		q = q.Limit(cond.Limit).Offset(cond.Offset)
 	}
-	if len(cond.Roles) > 0 {
-		q = q.Where("role IN ?", cond.Roles)
+
+	allowedSort := map[string]bool{"name": true, "role": true, "status": true, "created_at": true}
+	sort := "id"
+	if cond.Sort != "" && allowedSort[cond.Sort] {
+		sort = cond.Sort
 	}
+	if cond.SortType == "desc" {
+		q = q.Order(sort + " DESC")
+	} else {
+		q = q.Order(sort + " ASC")
+	}
+
 	var ms []*model.Staff
 	if err := q.Find(&ms).Error; err != nil {
 		return nil, err
@@ -42,6 +63,17 @@ func (r *GormStaffRepository) FindByCondition(cond domstaff.Condition) ([]*domst
 		out = append(out, staffToDomain(m))
 	}
 	return out, nil
+}
+
+func (r *GormStaffRepository) applyFilters(q *gorm.DB, cond domstaff.Condition) *gorm.DB {
+	if cond.Keyword != nil && *cond.Keyword != "" {
+		like := "%" + *cond.Keyword + "%"
+		q = q.Where("name LIKE ? OR email LIKE ?", like, like)
+	}
+	if len(cond.Roles) > 0 {
+		q = q.Where("role IN ?", cond.Roles)
+	}
+	return q
 }
 
 // FindByID はIDでスタッフエンティティを返します。存在しない場合は nil を返します。

--- a/backends/go-gin/internal/usecase/staff/interactor.go
+++ b/backends/go-gin/internal/usecase/staff/interactor.go
@@ -18,6 +18,11 @@ func NewInteractor(repo domstaff.Repository) *Interactor {
 	return &Interactor{repo: repo}
 }
 
+// CountByCondition は検索条件に合致するスタッフの総件数を返します。
+func (uc *Interactor) CountByCondition(cond domstaff.Condition) (int, error) {
+	return uc.repo.CountByCondition(cond)
+}
+
 // FindByCondition は検索条件に合致するスタッフ一覧の値オブジェクトを返します。
 //
 // cond: 検索条件

--- a/backends/go-gin/tests/client_test.go
+++ b/backends/go-gin/tests/client_test.go
@@ -169,10 +169,11 @@ func TestClient_SoftDelete(t *testing.T) {
 		if w.Code != http.StatusOK {
 			t.Errorf("want 200, got %d", w.Code)
 		}
-		var list []map[string]interface{}
-		json.Unmarshal(w.Body.Bytes(), &list)
-		if len(list) != 1 {
-			t.Errorf("want 1 item (including soft-deleted), got %d", len(list))
+		var response map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &response)
+		data := response["data"].([]interface{})
+		if len(data) != 1 {
+			t.Errorf("want 1 item (including soft-deleted), got %d", len(data))
 		}
 	})
 

--- a/backends/go-gin/tests/schema.sql
+++ b/backends/go-gin/tests/schema.sql
@@ -3,6 +3,7 @@
 
 SET FOREIGN_KEY_CHECKS=0;
 
+DROP TABLE IF EXISTS `jwt_histories`;
 DROP TABLE IF EXISTS `notifications`;
 DROP TABLE IF EXISTS `invitations`;
 DROP TABLE IF EXISTS `clients`;
@@ -73,6 +74,23 @@ CREATE TABLE `invitations` (
     `version`       INT UNSIGNED    NOT NULL DEFAULT 1,
     PRIMARY KEY (`id`),
     UNIQUE KEY `invitations_token_unique` (`token`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `jwt_histories` (
+    `id`         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `client_id`  BIGINT UNSIGNED NOT NULL,
+    `member_id`  VARCHAR(255)    NOT NULL,
+    `issue_at`   TIMESTAMP       NOT NULL,
+    `jwt`        TEXT            NOT NULL,
+    `created_at` TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `created_by` INT UNSIGNED    NOT NULL DEFAULT 0,
+    `updated_at` TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `updated_by` INT UNSIGNED    NOT NULL DEFAULT 0,
+    `deleted_at` TIMESTAMP       NULL,
+    `deleted_by` INT UNSIGNED    NULL,
+    `version`    INT UNSIGNED    NOT NULL DEFAULT 1,
+    PRIMARY KEY (`id`),
+    CONSTRAINT `fk_jwt_histories_client_id` FOREIGN KEY (`client_id`) REFERENCES `clients` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `notifications` (

--- a/backends/go-gin/tests/staff_test.go
+++ b/backends/go-gin/tests/staff_test.go
@@ -17,8 +17,11 @@ func TestStaff_Index(t *testing.T) {
 			t.Errorf("want 200, got %d: %s", w.Code, w.Body.String())
 		}
 		body := parseBody(w)
-		if body["items"] == nil {
-			t.Error("items not found in response")
+		if body["data"] == nil {
+			t.Error("data not found in response")
+		}
+		if body["pager"] == nil {
+			t.Error("pager not found in response")
 		}
 	})
 
@@ -29,9 +32,9 @@ func TestStaff_Index(t *testing.T) {
 			t.Errorf("want 200, got %d", w.Code)
 		}
 		body := parseBody(w)
-		items, ok := body["items"].([]interface{})
-		if !ok || len(items) != 0 {
-			t.Errorf("want empty items, got %v", body["items"])
+		data, ok := body["data"].([]interface{})
+		if !ok || len(data) != 0 {
+			t.Errorf("want empty data, got %v", body["data"])
 		}
 	})
 }

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/staff/Condition.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/staff/Condition.kt
@@ -11,6 +11,10 @@ package com.authorization.domain.staff
  * @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
  */
 data class Condition(
-    val keyword: String?    = null,
-    val roles:   List<Int>  = emptyList(),
+    val keyword:  String?   = null,
+    val roles:    List<Int> = emptyList(),
+    val offset:   Int       = 0,
+    val limit:    Int       = 20,
+    val sort:     String?   = null,
+    val sortType: String?   = null,
 )

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/staff/Repository.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/domain/staff/Repository.kt
@@ -13,6 +13,14 @@ package com.authorization.domain.staff
 interface Repository {
 
     /**
+     * 検索条件に一致するスタッフの総件数を返します。
+     *
+     * @param cond 検索条件
+     * @return 総件数
+     */
+    suspend fun countByCondition(cond: Condition): Int
+
+    /**
      * 検索条件に一致するスタッフ一覧を取得します。
      *
      * @param cond 検索条件

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/handler/StaffHandler.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/handler/StaffHandler.kt
@@ -19,6 +19,34 @@ import java.time.format.DateTimeFormatter
 
 private val fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
 
+private const val DEFAULT_PAGE_COUNT = 5
+
+private fun buildPager(count: Int, limit: Int, offset: Int, recordCount: Int): JsonObject {
+    val effectiveLimit = if (limit <= 0) 20 else limit
+    val pageCount = maxOf(1, kotlin.math.ceil(count.toDouble() / effectiveLimit).toInt())
+    val lastPageOffset = (pageCount * effectiveLimit) - effectiveLimit
+    val effectiveOffset = if (count > 0 && offset > lastPageOffset) lastPageOffset else offset
+    val page = (kotlin.math.ceil(effectiveOffset.toDouble() / effectiveLimit).toInt()) + 1
+    val startPage = maxOf(1, page - (DEFAULT_PAGE_COUNT - 1))
+    val endPage = minOf(pageCount, startPage + (DEFAULT_PAGE_COUNT - 1))
+    return buildJsonObject {
+        put("count", count)
+        put("limit", effectiveLimit)
+        put("next", pageCount > page)
+        put("previous", page > 1)
+        put("page", page)
+        put("nextPage", page + 1)
+        put("previousPage", page - 1)
+        put("pageCount", pageCount)
+        put("first", page > 1)
+        put("last", pageCount > page)
+        put("firstRecordCount", effectiveOffset + 1)
+        put("lastRecordCount", effectiveOffset + recordCount)
+        put("startPage", startPage)
+        put("endPage", endPage)
+    }
+}
+
 /**
  * スタッフ API のハンドラーです。
  *
@@ -32,13 +60,22 @@ class StaffHandler(private val staffUC: StaffUC) {
      * @param call アプリケーションコール
      */
     suspend fun index(call: ApplicationCall) {
-        val keyword = call.request.queryParameters["keyword"]
-        val roles = call.request.queryParameters.getAll("roles")
+        val keyword  = call.request.queryParameters["keyword"]
+        val roles    = call.request.queryParameters.getAll("roles")
             ?.flatMap { it.split(",") }
             ?.mapNotNull { it.trim().toIntOrNull() }
             ?: emptyList()
-        val staffs = staffUC.findByCondition(Condition(keyword = keyword, roles = roles))
-        val items = buildJsonArray {
+        val sort     = call.request.queryParameters["sort"]
+        val sortType = call.request.queryParameters["sort_type"]
+        val limit    = call.request.queryParameters["limit"]?.toIntOrNull()?.coerceAtLeast(1) ?: 20
+        val page     = call.request.queryParameters["page"]?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+        val offset   = limit * (page - 1)
+
+        val cond = Condition(keyword = keyword, roles = roles, offset = offset, limit = limit, sort = sort, sortType = sortType)
+        val (staffs, count) = staffUC.findByConditionWithCount(cond)
+        val pager = buildPager(count, limit, offset, staffs.size)
+
+        val data = buildJsonArray {
             staffs.forEach { s ->
                 add(buildJsonObject {
                     put("id",         s.id)
@@ -51,7 +88,10 @@ class StaffHandler(private val staffUC: StaffUC) {
                 })
             }
         }
-        call.respond(buildJsonObject { put("items", items) })
+        call.respond(buildJsonObject {
+            put("data", data)
+            put("pager", pager)
+        })
     }
 
     /**

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/persistence/ExposedStaffRepository.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/infrastructure/persistence/ExposedStaffRepository.kt
@@ -30,6 +30,23 @@ import java.time.LocalDateTime
 class ExposedStaffRepository(private val db: Database) : Repository {
 
     /**
+     * 検索条件に一致するスタッフの総件数を返します。
+     *
+     * @param cond 検索条件
+     * @return 総件数
+     */
+    override suspend fun countByCondition(cond: Condition): Int = newSuspendedTransaction(db = db) {
+        var query = Staffs.selectAll()
+        cond.keyword?.let { kw ->
+            query = query.andWhere { (Staffs.name like "%$kw%") or (Staffs.email like "%$kw%") }
+        }
+        if (cond.roles.isNotEmpty()) {
+            query = query.andWhere { Staffs.role inList cond.roles }
+        }
+        query.count().toInt()
+    }
+
+    /**
      * 検索条件に一致するスタッフ一覧を取得します。
      *
      * @param cond 検索条件
@@ -43,7 +60,17 @@ class ExposedStaffRepository(private val db: Database) : Repository {
         if (cond.roles.isNotEmpty()) {
             query = query.andWhere { Staffs.role inList cond.roles }
         }
-        query.orderBy(Staffs.createdAt to SortOrder.DESC).map { rowToStaff(it) }
+
+        val sortOrder = if (cond.sortType == "desc") SortOrder.DESC else SortOrder.ASC
+        val sortCol: org.jetbrains.exposed.sql.Expression<*> = when (cond.sort) {
+            "name"       -> Staffs.name
+            "role"       -> Staffs.role
+            "created_at" -> Staffs.createdAt
+            else         -> Staffs.id
+        }
+        query = query.orderBy(sortCol to sortOrder)
+
+        query.limit(cond.limit, cond.offset.toLong()).map { rowToStaff(it) }
     }
 
     /**

--- a/backends/kotlin-ktor/src/main/kotlin/com/authorization/usecase/staff/Interactor.kt
+++ b/backends/kotlin-ktor/src/main/kotlin/com/authorization/usecase/staff/Interactor.kt
@@ -18,13 +18,14 @@ import com.authorization.support.AppException
 class Interactor(private val repo: Repository) {
 
     /**
-     * 検索条件に一致するスタッフ一覧を取得します。
+     * 検索条件に一致するスタッフ一覧と総件数を取得します。
      *
      * @param cond 検索条件
-     * @return スタッフ一覧
+     * @return スタッフ一覧と総件数のペア
      */
-    suspend fun findByCondition(cond: Condition): List<ListItem> =
-        repo.findByCondition(cond).map { s ->
+    suspend fun findByConditionWithCount(cond: Condition): Pair<List<ListItem>, Int> {
+        val count = repo.countByCondition(cond)
+        val items = repo.findByCondition(cond).map { s ->
             ListItem(
                 id        = s.id,
                 name      = s.name,
@@ -35,6 +36,8 @@ class Interactor(private val repo: Repository) {
                 updatedAt = s.updatedAt,
             )
         }
+        return Pair(items, count)
+    }
 
     /**
      * スタッフのロールを更新します。

--- a/backends/kotlin-ktor/src/test/kotlin/com/authorization/integration/StaffIntegrationTest.kt
+++ b/backends/kotlin-ktor/src/test/kotlin/com/authorization/integration/StaffIntegrationTest.kt
@@ -30,7 +30,8 @@ class StaffIntegrationTest {
         val response = client.get("/api/staffs")
         assertEquals(HttpStatusCode.OK, response.status)
         val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
-        assertEquals(2, body["items"]!!.jsonArray.size)
+        assertEquals(2, body["data"]!!.jsonArray.size)
+        assert(body["pager"] != null)
     }
 
     @Test
@@ -39,7 +40,7 @@ class StaffIntegrationTest {
         val response = client.get("/api/staffs")
         assertEquals(HttpStatusCode.OK, response.status)
         val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
-        assertEquals(0, body["items"]!!.jsonArray.size)
+        assertEquals(0, body["data"]!!.jsonArray.size)
     }
 
     @Test

--- a/backends/kotlin-ktor/src/test/kotlin/com/authorization/usecase/client/InteractorTest.kt
+++ b/backends/kotlin-ktor/src/test/kotlin/com/authorization/usecase/client/InteractorTest.kt
@@ -36,6 +36,7 @@ class InteractorTest {
         byIdentifier: Client?      = null,
         saveResult: Client?        = null,
     ): Repository = object : Repository {
+        override suspend fun countByCondition(cond: Condition) = 0
         override suspend fun findByCondition(cond: Condition) = byCondition
         override suspend fun findById(id: Long)               = byId
         override suspend fun findByAccessToken(token: String) = byToken

--- a/backends/kotlin-ktor/src/test/kotlin/com/authorization/usecase/gate/InteractorTest.kt
+++ b/backends/kotlin-ktor/src/test/kotlin/com/authorization/usecase/gate/InteractorTest.kt
@@ -59,6 +59,7 @@ class InteractorTest {
         byToken: Client? = null,
         byIdentifier: Client? = null,
     ): ClientRepository = object : ClientRepository {
+        override suspend fun countByCondition(cond: Condition) = 0
         override suspend fun findByCondition(cond: Condition) = emptyList<Client>()
         override suspend fun findById(id: Long)               = null
         override suspend fun findByAccessToken(token: String) = byToken

--- a/backends/python-fastapi/app/domain/staff/condition.py
+++ b/backends/python-fastapi/app/domain/staff/condition.py
@@ -12,3 +12,7 @@ class StaffCondition:
     """スタッフ検索条件。"""
     keyword: Optional[str] = None
     roles: list[int] = field(default_factory=list)
+    offset: int = 0
+    limit: int = 20
+    sort: Optional[str] = None
+    sort_type: Optional[str] = None

--- a/backends/python-fastapi/app/domain/staff/repository.py
+++ b/backends/python-fastapi/app/domain/staff/repository.py
@@ -13,6 +13,18 @@ class StaffRepository(ABC):
     """スタッフの永続化インターフェース。"""
 
     @abstractmethod
+    def count_staffs(self, cond: StaffCondition) -> int:
+        """検索条件に合致するスタッフの総件数を返します。
+
+        Args:
+            cond: 検索条件
+
+        Returns:
+            総件数
+        """
+        ...
+
+    @abstractmethod
     def find_all_staffs(self, cond: StaffCondition) -> list[Staff]:
         """検索条件に合致するスタッフの一覧を返します。
 

--- a/backends/python-fastapi/app/infrastructure/persistence/sqlalchemy_staff_repository.py
+++ b/backends/python-fastapi/app/infrastructure/persistence/sqlalchemy_staff_repository.py
@@ -6,7 +6,7 @@ Author: Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
 from typing import Optional
 
 from datetime import datetime, timezone
-from sqlalchemy import or_
+from sqlalchemy import or_, asc, desc
 from sqlalchemy.orm import Session
 
 from app.domain.staff.entity import Staff
@@ -35,6 +35,27 @@ class SqlAlchemyStaffRepository(StaffRepository):
         """
         self.db = db
 
+    def _apply_filters(self, q, cond: StaffCondition):
+        if cond.keyword:
+            like = f"%{cond.keyword}%"
+            q = q.filter(or_(StaffModel.name.like(like), StaffModel.email.like(like)))
+        if cond.roles:
+            q = q.filter(StaffModel.role.in_(cond.roles))
+        return q
+
+    def count_staffs(self, cond: StaffCondition) -> int:
+        """検索条件に合致するスタッフの総件数を返します。
+
+        Args:
+            cond: 検索条件
+
+        Returns:
+            総件数
+        """
+        q = self.db.query(StaffModel)
+        q = self._apply_filters(q, cond)
+        return q.count()
+
     def find_all_staffs(self, cond: StaffCondition) -> list[Staff]:
         """検索条件に合致するスタッフエンティティを返します。
 
@@ -45,12 +66,14 @@ class SqlAlchemyStaffRepository(StaffRepository):
             スタッフエンティティのリスト
         """
         q = self.db.query(StaffModel)
-        if cond.keyword:
-            like = f"%{cond.keyword}%"
-            q = q.filter(or_(StaffModel.name.like(like), StaffModel.email.like(like)))
-        if cond.roles:
-            q = q.filter(StaffModel.role.in_(cond.roles))
-        return [_to_entity(m) for m in q.order_by(StaffModel.id).all()]
+        q = self._apply_filters(q, cond)
+
+        _allowed_sort = {"name": StaffModel.name, "role": StaffModel.role, "created_at": StaffModel.created_at}
+        sort_col = _allowed_sort.get(cond.sort, StaffModel.id) if cond.sort else StaffModel.id
+        order_fn = desc if cond.sort_type == "desc" else asc
+        q = q.order_by(order_fn(sort_col))
+
+        return [_to_entity(m) for m in q.offset(cond.offset).limit(cond.limit).all()]
 
     def find_staff_by_id(self, staff_id: int) -> Optional[Staff]:
         """IDで有効なスタッフエンティティを返します。存在しない場合は None を返します。

--- a/backends/python-fastapi/app/routers/staffs.py
+++ b/backends/python-fastapi/app/routers/staffs.py
@@ -3,6 +3,7 @@
 
 Author: Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
 """
+import math
 from typing import Optional
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
@@ -11,6 +12,36 @@ from app.usecase.staff.interactor import StaffInteractor
 from app.usecase.staff.dto import StaffUpdateRoleDto, StaffDestroyDto
 
 router = APIRouter()
+
+_DEFAULT_PAGE_COUNT = 5
+
+
+def _build_pager(count: int, limit: int, offset: int, record_count: int) -> dict:
+    if limit <= 0:
+        limit = 20
+    page_count = max(1, math.ceil(count / limit))
+    last_page_offset = (page_count * limit) - limit
+    if count > 0 and offset > last_page_offset:
+        offset = last_page_offset
+    page = int(math.floor(math.ceil(offset / limit))) + 1 if limit > 0 else 1
+    start_page = max(1, page - (_DEFAULT_PAGE_COUNT - 1))
+    end_page = min(page_count, start_page + (_DEFAULT_PAGE_COUNT - 1))
+    return {
+        "count": count,
+        "limit": limit,
+        "next": page_count > page,
+        "previous": page > 1,
+        "page": page,
+        "nextPage": page + 1,
+        "previousPage": page - 1,
+        "pageCount": page_count,
+        "first": page > 1,
+        "last": page_count > page,
+        "firstRecordCount": offset + 1,
+        "lastRecordCount": offset + record_count,
+        "startPage": start_page,
+        "endPage": end_page,
+    }
 
 
 def _map_staff(s) -> dict:
@@ -29,10 +60,18 @@ def _map_staff(s) -> dict:
 def index(
     keyword: Optional[str] = Query(default=None),
     roles: Optional[list[int]] = Query(default=None),
+    limit: int = Query(default=20, ge=1),
+    page: int = Query(default=1, ge=1),
+    sort: Optional[str] = Query(default=None),
+    sort_type: Optional[str] = Query(default=None),
     interactor: StaffInteractor = Depends(get_staff_interactor),
 ):
-    staffs = interactor.find_by_condition(keyword=keyword, roles=roles or [])
-    return {"items": [_map_staff(s) for s in staffs]}
+    offset = limit * (page - 1)
+    staffs, count = interactor.find_by_condition(
+        keyword=keyword, roles=roles or [], offset=offset, limit=limit, sort=sort, sort_type=sort_type
+    )
+    pager = _build_pager(count, limit, offset, len(staffs))
+    return {"data": [_map_staff(s) for s in staffs], "pager": pager}
 
 
 class UpdateRoleBody(BaseModel):

--- a/backends/python-fastapi/app/usecase/staff/interactor.py
+++ b/backends/python-fastapi/app/usecase/staff/interactor.py
@@ -53,19 +53,28 @@ class StaffInteractor:
         self,
         keyword: Optional[str] = None,
         roles: Optional[list[int]] = None,
-    ) -> list[StaffListItem]:
-        """検索条件に合致するスタッフ一覧の Vo を返します。
+        offset: int = 0,
+        limit: int = 20,
+        sort: Optional[str] = None,
+        sort_type: Optional[str] = None,
+    ) -> tuple[list[StaffListItem], int]:
+        """検索条件に合致するスタッフ一覧の Vo と総件数を返します。
 
         Args:
             keyword: キーワード検索文字列
             roles: ロールフィルター
+            offset: オフセット
+            limit: 取得件数
+            sort: ソート対象
+            sort_type: ソート順
 
         Returns:
-            StaffListItem のリスト
+            StaffListItem のリストと総件数のタプル
         """
-        cond = StaffCondition(keyword=keyword, roles=roles or [])
+        cond = StaffCondition(keyword=keyword, roles=roles or [], offset=offset, limit=limit, sort=sort, sort_type=sort_type)
+        count = self.repository.count_staffs(cond)
         staffs = self.repository.find_all_staffs(cond)
-        return [_to_list_item(s) for s in staffs]
+        return [_to_list_item(s) for s in staffs], count
 
     def update_role(self, dto: StaffUpdateRoleDto) -> None:
         """スタッフの権限を更新します。

--- a/backends/python-fastapi/tests/test_clients.py
+++ b/backends/python-fastapi/tests/test_clients.py
@@ -10,8 +10,8 @@ class TestIndex:
         res = client.get("/api/clients")
         assert res.status_code == 200
         data = res.json()
-        assert isinstance(data, list)
-        assert len(data) == 2
+        assert isinstance(data["data"], list)
+        assert len(data["data"]) == 2
 
     def test_キーワードでフィルタできる(self, client, db_session):
         make_client_record(db_session, identifier="c-001", name="株式会社テスト")
@@ -19,13 +19,13 @@ class TestIndex:
         res = client.get("/api/clients?keyword=テスト")
         assert res.status_code == 200
         data = res.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "株式会社テスト"
+        assert len(data["data"]) == 1
+        assert data["data"][0]["name"] == "株式会社テスト"
 
     def test_クライアントが存在しない場合空リストを返す(self, client):
         res = client.get("/api/clients")
         assert res.status_code == 200
-        assert res.json() == []
+        assert res.json()["data"] == []
 
 
 class TestShow:
@@ -95,7 +95,7 @@ class TestSoftDelete:
         res = client.get("/api/clients")
         assert res.status_code == 200
         data = res.json()
-        assert len(data) == 1
+        assert len(data["data"]) == 1
 
     def test_論理削除済みのクライアント詳細が取得できる(self, client, db_session):
         c = make_client_record(db_session)

--- a/backends/python-fastapi/tests/test_staffs.py
+++ b/backends/python-fastapi/tests/test_staffs.py
@@ -9,23 +9,24 @@ class TestIndex:
         make_staff(db_session, email="staff2@example.com", name="別スタッフ", role=2)
         res = client.get("/api/staffs")
         assert res.status_code == 200
-        data = res.json()
-        assert "items" in data
-        assert len(data["items"]) == 2
+        body = res.json()
+        assert "data" in body
+        assert "pager" in body
+        assert len(body["data"]) == 2
 
     def test_キーワードでフィルタできる(self, client, db_session):
         make_staff(db_session, email="admin@example.com", name="管理者スタッフ")
         make_staff(db_session, email="member@example.com", name="メンバースタッフ")
         res = client.get("/api/staffs?keyword=管理者")
         assert res.status_code == 200
-        items = res.json()["items"]
-        assert len(items) == 1
-        assert items[0]["name"] == "管理者スタッフ"
+        data = res.json()["data"]
+        assert len(data) == 1
+        assert data[0]["name"] == "管理者スタッフ"
 
     def test_スタッフが存在しない場合空リストを返す(self, client):
         res = client.get("/api/staffs")
         assert res.status_code == 200
-        assert res.json()["items"] == []
+        assert res.json()["data"] == []
 
 
 class TestUpdateRole:

--- a/backends/ruby-hanami/app/actions/staffs/index.rb
+++ b/backends/ruby-hanami/app/actions/staffs/index.rb
@@ -16,12 +16,24 @@ module Authorization
         # @param response [Hanami::Action::Response] レスポンス
         # @return [void]
         def handle(request, response)
+          limit  = (request.params[:limit]  || 20).to_i
+          page   = (request.params[:page]   || 1).to_i
+          offset = limit * (page - 1)
           keyword = request.params[:keyword]
           roles   = Array(request.params[:roles]).flat_map { |r| r.to_s.split(",") }.filter_map(&:to_i)
-          staffs  = container[:staff_uc].find_by_condition(
-            ::Domain::Staff::Condition.new(keyword: keyword, roles: roles)
+
+          result = container[:staff_uc].find_by_condition(
+            ::Domain::Staff::Condition.new(
+              keyword:   keyword,
+              roles:     roles,
+              offset:    offset,
+              limit:     limit,
+              sort:      request.params[:sort],
+              sort_type: request.params[:sort_type],
+            )
           )
-          json_response(response, { items: staffs.map { |s|
+
+          data = result[:items].map { |s|
             {
               id:         s.id,
               name:       s.name,
@@ -31,7 +43,9 @@ module Authorization
               created_at: s.created_at.strftime(TIME_FORMAT),
               updated_at: s.updated_at.strftime(TIME_FORMAT),
             }
-          }})
+          }
+          pager = build_pager(result[:count], limit, offset, data.size)
+          json_response(response, { data: data, pager: pager })
         end
       end
     end

--- a/backends/ruby-hanami/app/domain/staff/condition.rb
+++ b/backends/ruby-hanami/app/domain/staff/condition.rb
@@ -7,6 +7,6 @@
 module Domain
   module Staff
     # スタッフ一覧取得の検索条件です。
-    Condition = Struct.new(:keyword, :roles, keyword_init: true)
+    Condition = Struct.new(:keyword, :roles, :offset, :limit, :sort, :sort_type, keyword_init: true)
   end
 end

--- a/backends/ruby-hanami/app/domain/staff/repository.rb
+++ b/backends/ruby-hanami/app/domain/staff/repository.rb
@@ -9,6 +9,10 @@ module Domain
     # スタッフリポジトリのインターフェースです。
     module Repository
       # @param cond [Domain::Staff::Condition] 検索条件
+      # @return [Integer] 総件数
+      def count_by_condition(cond)                  = raise NotImplementedError
+
+      # @param cond [Domain::Staff::Condition] 検索条件
       # @return [Array<Domain::Staff::Entity>] スタッフエンティティの配列
       def find_by_condition(cond)                   = raise NotImplementedError
 

--- a/backends/ruby-hanami/app/infrastructure/persistence/rom_staff_repository.rb
+++ b/backends/ruby-hanami/app/infrastructure/persistence/rom_staff_repository.rb
@@ -7,16 +7,33 @@ module Infrastructure
         @ds = rom.gateways[:default].connection[:staffs]
       end
 
-      def find_by_condition(cond)
-        q = @ds
+      ALLOWED_SORT = %w[name role created_at].freeze
 
+      def apply_filters(q, cond)
         if cond.keyword && !cond.keyword.to_s.empty?
           kw = "%#{cond.keyword}%"
           q = q.where(Sequel.|(Sequel.like(:name, kw), Sequel.like(:email, kw)))
         end
-
         q = q.where(role: cond.roles) if cond.roles && !cond.roles.empty?
-        q.order(Sequel.desc(:created_at)).all.map { |r| row_to_list_item(r) }
+        q
+      end
+
+      def count_by_condition(cond)
+        apply_filters(@ds, cond).count
+      end
+
+      def find_by_condition(cond)
+        q = apply_filters(@ds, cond)
+
+        sort_col = ALLOWED_SORT.include?(cond.sort) ? cond.sort.to_sym : :id
+        sort_dir = cond.sort_type == "desc" ? :desc : :asc
+        q = q.order(Sequel.send(sort_dir, sort_col))
+
+        limit  = (cond.limit  || 20).to_i
+        offset = (cond.offset || 0).to_i
+        q = q.limit(limit).offset(offset) if limit > 0
+
+        q.all.map { |r| row_to_list_item(r) }
       end
 
       def find_by_id(id)

--- a/backends/ruby-hanami/app/usecase/staff/interactor.rb
+++ b/backends/ruby-hanami/app/usecase/staff/interactor.rb
@@ -15,7 +15,9 @@ module UseCase
       end
 
       def find_by_condition(cond)
-        @repo.find_by_condition(cond)
+        count = @repo.count_by_condition(cond)
+        items = @repo.find_by_condition(cond)
+        { items: items, count: count }
       end
 
       def update_role(dto)

--- a/backends/ruby-hanami/spec/requests/clients_spec.rb
+++ b/backends/ruby-hanami/spec/requests/clients_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe "Clients" do
       get "/api/clients"
       expect(last_response.status).to eq(200)
       body = JSON.parse(last_response.body)
-      expect(body).to be_an(Array)
-      expect(body.size).to eq(2)
+      expect(body["data"]).to be_an(Array)
+      expect(body["data"].size).to eq(2)
     end
 
     it "クライアントが存在しない場合空リストを返す" do
       get "/api/clients"
       expect(last_response.status).to eq(200)
-      expect(JSON.parse(last_response.body)).to eq([])
+      expect(JSON.parse(last_response.body)["data"]).to eq([])
     end
   end
 

--- a/backends/ruby-hanami/spec/requests/staffs_spec.rb
+++ b/backends/ruby-hanami/spec/requests/staffs_spec.rb
@@ -12,15 +12,16 @@ RSpec.describe "Staffs" do
       get "/api/staffs"
       expect(last_response.status).to eq(200)
       body = JSON.parse(last_response.body)
-      expect(body["items"]).to be_an(Array)
-      expect(body["items"].size).to eq(2)
+      expect(body["data"]).to be_an(Array)
+      expect(body["data"].size).to eq(2)
+      expect(body["pager"]).to be_a(Hash)
     end
 
     it "スタッフが存在しない場合空リストを返す" do
       get "/api/staffs"
       expect(last_response.status).to eq(200)
       body = JSON.parse(last_response.body)
-      expect(body["items"]).to eq([])
+      expect(body["data"]).to eq([])
     end
   end
 

--- a/backends/ruby-hanami/spec/usecase/client/interactor_spec.rb
+++ b/backends/ruby-hanami/spec/usecase/client/interactor_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe UseCase::Client::Interactor do
 
   let(:stub_repo) do
     double("ClientRepo",
+      count_by_condition:  0,
       find_by_condition:   [],
       find_by_id:          make_entity.call,
       save:                make_entity.call,
@@ -32,11 +33,13 @@ RSpec.describe UseCase::Client::Interactor do
   end
 
   describe "#find_by_condition" do
-    it "returns list from repo" do
+    it "returns items and count from repo" do
+      allow(stub_repo).to receive(:count_by_condition).and_return(1)
       allow(stub_repo).to receive(:find_by_condition).and_return([make_entity.call])
       dto = UseCase::Client::ListConditionDto.new(keyword: nil, start_from: nil, start_to: nil, statuses: nil)
       result = described_class.new(stub_repo).find_by_condition(dto)
-      expect(result.size).to eq 1
+      expect(result[:items].size).to eq 1
+      expect(result[:count]).to eq 1
     end
   end
 

--- a/backends/ruby-hanami/spec/usecase/staff/interactor_spec.rb
+++ b/backends/ruby-hanami/spec/usecase/staff/interactor_spec.rb
@@ -5,22 +5,25 @@ require "spec_helper"
 RSpec.describe UseCase::Staff::Interactor do
   let(:stub_repo) do
     double("StaffRepo",
-      find_by_condition: [],
-      update_role:       true,
-      soft_delete:       true,
-      restore:           true,
+      count_by_condition: 0,
+      find_by_condition:  [],
+      update_role:        true,
+      soft_delete:        true,
+      restore:            true,
     )
   end
 
   describe "#find_by_condition" do
-    it "returns list from repo" do
+    it "returns items and count from repo" do
       items = [
         Domain::Staff::ListItem.new(id: 1, name: "S1", email: "s1@example.com", role: 2,
           status: :active, created_at: Time.now, updated_at: Time.now),
       ]
+      allow(stub_repo).to receive(:count_by_condition).and_return(1)
       allow(stub_repo).to receive(:find_by_condition).and_return(items)
       result = described_class.new(stub_repo).find_by_condition(Domain::Staff::Condition.new)
-      expect(result.size).to eq 1
+      expect(result[:items].size).to eq 1
+      expect(result[:count]).to eq 1
     end
   end
 

--- a/backends/ruby-rails/app/controllers/api/staffs_controller.rb
+++ b/backends/ruby-rails/app/controllers/api/staffs_controller.rb
@@ -9,12 +9,24 @@
 class Api::StaffsController < Api::BaseController
   # スタッフ一覧を返します。
   def index
+    limit  = (params[:limit]  || 20).to_i
+    page   = (params[:page]   || 1).to_i
+    offset = limit * (page - 1)
     keyword = params[:keyword]
     roles   = Array(params[:roles]).flat_map { |r| r.to_s.split(",") }.filter_map(&:to_i)
-    staffs  = container[:staff_uc].find_by_condition(
-      Domain::Staff::Condition.new(keyword: keyword, roles: roles)
+
+    result = container[:staff_uc].find_by_condition(
+      Domain::Staff::Condition.new(
+        keyword:   keyword,
+        roles:     roles,
+        offset:    offset,
+        limit:     limit,
+        sort:      params[:sort],
+        sort_type: params[:sort_type],
+      )
     )
-    render json: { items: staffs.map { |s|
+
+    data = result[:items].map { |s|
       {
         id:         s.id,
         name:       s.name,
@@ -24,7 +36,9 @@ class Api::StaffsController < Api::BaseController
         created_at: s.created_at.strftime(TIME_FORMAT),
         updated_at: s.updated_at.strftime(TIME_FORMAT),
       }
-    }}
+    }
+    pager = build_pager(result[:count], limit, offset, data.size)
+    render json: { data: data, pager: pager }
   end
 
   # スタッフのロールを更新します。

--- a/backends/ruby-rails/app/domain/staff/condition.rb
+++ b/backends/ruby-rails/app/domain/staff/condition.rb
@@ -7,6 +7,6 @@
 module Domain
   module Staff
     # スタッフ一覧取得の検索条件です。
-    Condition = Struct.new(:keyword, :roles, keyword_init: true)
+    Condition = Struct.new(:keyword, :roles, :offset, :limit, :sort, :sort_type, keyword_init: true)
   end
 end

--- a/backends/ruby-rails/app/domain/staff/repository.rb
+++ b/backends/ruby-rails/app/domain/staff/repository.rb
@@ -9,6 +9,10 @@ module Domain
     # スタッフリポジトリのインターフェースです。
     module Repository
       # @param cond [Domain::Staff::Condition] 検索条件
+      # @return [Integer] 総件数
+      def count_by_condition(cond)                  = raise NotImplementedError
+
+      # @param cond [Domain::Staff::Condition] 検索条件
       # @return [Array<Domain::Staff::Entity>] スタッフエンティティの配列
       def find_by_condition(cond)                   = raise NotImplementedError
 

--- a/backends/ruby-rails/app/infrastructure/persistence/active_record_staff_repository.rb
+++ b/backends/ruby-rails/app/infrastructure/persistence/active_record_staff_repository.rb
@@ -13,13 +13,30 @@ module Infrastructure
         @model = Infrastructure::Model::Staff
       end
 
-      def find_by_condition(cond)
-        q = @model.all
-        if cond.keyword.present?
-          q = q.where("name LIKE ? OR email LIKE ?", "%#{cond.keyword}%", "%#{cond.keyword}%")
-        end
+      ALLOWED_SORT = %w[name role created_at].freeze
+
+      def apply_filters(q, cond)
+        q = q.where("name LIKE ? OR email LIKE ?", "%#{cond.keyword}%", "%#{cond.keyword}%") if cond.keyword.present?
         q = q.where(role: cond.roles) if cond.roles.present?
-        q.order(created_at: :desc).map { |r| row_to_list_item(r) }
+        q
+      end
+
+      def count_by_condition(cond)
+        apply_filters(@model.all, cond).count
+      end
+
+      def find_by_condition(cond)
+        q = apply_filters(@model.all, cond)
+
+        sort_col = ALLOWED_SORT.include?(cond.sort) ? cond.sort : "id"
+        sort_dir = cond.sort_type == "desc" ? :desc : :asc
+        q = q.order(sort_col => sort_dir)
+
+        limit  = (cond.limit  || 20).to_i
+        offset = (cond.offset || 0).to_i
+        q = q.limit(limit).offset(offset) if limit > 0
+
+        q.map { |r| row_to_list_item(r) }
       end
 
       def find_by_id(id)

--- a/backends/ruby-rails/app/usecase/staff/interactor.rb
+++ b/backends/ruby-rails/app/usecase/staff/interactor.rb
@@ -15,7 +15,9 @@ module UseCase
       end
 
       def find_by_condition(cond)
-        @repo.find_by_condition(cond)
+        count = @repo.count_by_condition(cond)
+        items = @repo.find_by_condition(cond)
+        { items: items, count: count }
       end
 
       def update_role(dto)

--- a/backends/ruby-rails/spec/requests/clients_spec.rb
+++ b/backends/ruby-rails/spec/requests/clients_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe "Clients", type: :request do
       get "/api/clients"
       expect(response).to have_http_status(200)
       body = JSON.parse(response.body)
-      expect(body).to be_an(Array)
-      expect(body.size).to eq(2)
+      expect(body["data"]).to be_an(Array)
+      expect(body["data"].size).to eq(2)
     end
 
     it "クライアントが存在しない場合空リストを返す" do
       get "/api/clients"
       expect(response).to have_http_status(200)
-      expect(JSON.parse(response.body)).to eq([])
+      expect(JSON.parse(response.body)["data"]).to eq([])
     end
   end
 

--- a/backends/ruby-rails/spec/requests/staffs_spec.rb
+++ b/backends/ruby-rails/spec/requests/staffs_spec.rb
@@ -10,15 +10,16 @@ RSpec.describe "Staffs", type: :request do
       get "/api/staffs"
       expect(response).to have_http_status(200)
       body = JSON.parse(response.body)
-      expect(body["items"]).to be_an(Array)
-      expect(body["items"].size).to eq(2)
+      expect(body["data"]).to be_an(Array)
+      expect(body["data"].size).to eq(2)
+      expect(body["pager"]).to be_a(Hash)
     end
 
     it "スタッフが存在しない場合空リストを返す" do
       get "/api/staffs"
       expect(response).to have_http_status(200)
       body = JSON.parse(response.body)
-      expect(body["items"]).to eq([])
+      expect(body["data"]).to eq([])
     end
   end
 

--- a/backends/ruby-rails/spec/usecase/client/interactor_spec.rb
+++ b/backends/ruby-rails/spec/usecase/client/interactor_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe UseCase::Client::Interactor do
 
   let(:stub_repo) do
     double("ClientRepo",
+      count_by_condition:  0,
       find_by_condition:   [],
       find_by_id:          make_entity.call,
       save:                make_entity.call,
@@ -31,15 +32,17 @@ RSpec.describe UseCase::Client::Interactor do
   end
 
   describe "#find_by_condition" do
-    it "returns list items from repo" do
+    it "returns items and count from repo" do
       items = [
         Domain::Client::ListItem.new(id: 1, name: "C1", status: 1, start_at: nil, stop_at: nil, created_at: Time.current, updated_at: Time.current),
         Domain::Client::ListItem.new(id: 2, name: "C2", status: 1, start_at: nil, stop_at: nil, created_at: Time.current, updated_at: Time.current),
       ]
+      allow(stub_repo).to receive(:count_by_condition).and_return(2)
       allow(stub_repo).to receive(:find_by_condition).and_return(items)
       dto    = UseCase::Client::ListConditionDto.new
       result = described_class.new(stub_repo).find_by_condition(dto)
-      expect(result.size).to eq 2
+      expect(result[:items].size).to eq 2
+      expect(result[:count]).to eq 2
     end
   end
 

--- a/backends/ruby-rails/spec/usecase/staff/interactor_spec.rb
+++ b/backends/ruby-rails/spec/usecase/staff/interactor_spec.rb
@@ -5,21 +5,24 @@ require "rails_helper"
 RSpec.describe UseCase::Staff::Interactor do
   let(:stub_repo) do
     double("StaffRepo",
-      find_by_condition: [],
-      update_role:       true,
-      soft_delete:       true,
-      restore:           true,
+      count_by_condition: 0,
+      find_by_condition:  [],
+      update_role:        true,
+      soft_delete:        true,
+      restore:            true,
     )
   end
 
   describe "#find_by_condition" do
-    it "returns list from repo" do
+    it "returns items and count from repo" do
       items = [
         Domain::Staff::ListItem.new(id: 1, name: "S1", email: "s1@example.com", role: 2, status: :active, created_at: Time.current, updated_at: Time.current),
       ]
+      allow(stub_repo).to receive(:count_by_condition).and_return(1)
       allow(stub_repo).to receive(:find_by_condition).and_return(items)
       result = described_class.new(stub_repo).find_by_condition(Domain::Staff::Condition.new)
-      expect(result.size).to eq 1
+      expect(result[:items].size).to eq 1
+      expect(result[:count]).to eq 1
     end
   end
 

--- a/backends/rust-axum/src/domain/staff/condition.rs
+++ b/backends/rust-axum/src/domain/staff/condition.rs
@@ -4,7 +4,12 @@
 //! Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
 
 /// スタッフ一覧の検索条件。
+#[derive(Clone)]
 pub struct Condition {
-    pub keyword: Option<String>,
-    pub roles:   Vec<i32>,
+    pub keyword:   Option<String>,
+    pub roles:     Vec<i32>,
+    pub offset:    i64,
+    pub limit:     i64,
+    pub sort:      Option<String>,
+    pub sort_type: Option<String>,
 }

--- a/backends/rust-axum/src/domain/staff/repository.rs
+++ b/backends/rust-axum/src/domain/staff/repository.rs
@@ -11,6 +11,8 @@ pub type DomainError = Box<dyn std::error::Error + Send + Sync>;
 /// スタッフのリポジトリインターフェース。
 #[async_trait]
 pub trait Repository: Send + Sync {
+    /// 検索条件に合致するスタッフ件数を返します。
+    async fn count_by_condition(&self, cond: Condition) -> Result<i64, DomainError>;
     /// 検索条件に合致するスタッフ一覧を返します。
     async fn find_by_condition(&self, cond: Condition) -> Result<Vec<Staff>, DomainError>;
     /// ID でスタッフを返します（論理削除済みは除く）。

--- a/backends/rust-axum/src/handler/staff.rs
+++ b/backends/rust-axum/src/handler/staff.rs
@@ -21,8 +21,12 @@ use super::{staff_id_from_cookie, TIME_FORMAT};
 /// スタッフ一覧取得クエリ。
 #[derive(Deserialize)]
 pub struct IndexQuery {
-    pub keyword: Option<String>,
-    pub roles:   Option<String>,
+    pub keyword:   Option<String>,
+    pub roles:     Option<String>,
+    pub limit:     Option<i64>,
+    pub page:      Option<i64>,
+    pub sort:      Option<String>,
+    pub sort_type: Option<String>,
 }
 
 /// スタッフロール更新リクエストボディ。
@@ -38,20 +42,58 @@ pub struct DestroyBody {
     pub version: i32,
 }
 
+const DEFAULT_PAGE_COUNT: i64 = 5;
+
+fn build_pager(count: i64, limit: i64, offset: i64, record_count: i64) -> Value {
+    let effective_limit = if limit <= 0 { 20 } else { limit };
+    let page_count = std::cmp::max(1, (count as f64 / effective_limit as f64).ceil() as i64);
+    let last_page_offset = (page_count * effective_limit) - effective_limit;
+    let effective_offset = if count > 0 && offset > last_page_offset { last_page_offset } else { offset };
+    let page = (effective_offset as f64 / effective_limit as f64).ceil() as i64 + 1;
+    let start_page = std::cmp::max(1, page - (DEFAULT_PAGE_COUNT - 1));
+    let end_page = std::cmp::min(page_count, start_page + (DEFAULT_PAGE_COUNT - 1));
+    json!({
+        "count": count,
+        "limit": effective_limit,
+        "next": page_count > page,
+        "previous": page > 1,
+        "page": page,
+        "nextPage": page + 1,
+        "previousPage": page - 1,
+        "pageCount": page_count,
+        "first": page > 1,
+        "last": page_count > page,
+        "firstRecordCount": effective_offset + 1,
+        "lastRecordCount": effective_offset + record_count,
+        "startPage": start_page,
+        "endPage": end_page,
+    })
+}
+
 /// スタッフ一覧を返します。
 pub async fn index(
     State(state): State<AppState>,
     Query(q): Query<IndexQuery>,
 ) -> (StatusCode, Json<Value>) {
     use crate::domain::staff::condition::Condition;
+    let limit  = q.limit.unwrap_or(20).max(1);
+    let page   = q.page.unwrap_or(1).max(1);
+    let offset = limit * (page - 1);
     let roles = q.roles
         .as_deref()
         .map(|s| s.split(',').filter_map(|v| v.trim().parse::<i32>().ok()).collect())
         .unwrap_or_default();
-    let cond = Condition { keyword: q.keyword, roles };
-    match state.staff_uc.find_by_condition(cond).await {
-        Ok(staffs) => {
-            let items: Vec<Value> = staffs.iter().map(|s| json!({
+    let cond = Condition {
+        keyword:   q.keyword,
+        roles,
+        offset,
+        limit,
+        sort:      q.sort,
+        sort_type: q.sort_type,
+    };
+    match state.staff_uc.find_by_condition_with_count(cond).await {
+        Ok((staffs, count)) => {
+            let data: Vec<Value> = staffs.iter().map(|s| json!({
                 "id":         s.id,
                 "name":       s.name,
                 "email":      s.email,
@@ -60,7 +102,8 @@ pub async fn index(
                 "created_at": s.created_at.format(TIME_FORMAT).to_string(),
                 "updated_at": s.updated_at.format(TIME_FORMAT).to_string(),
             })).collect();
-            (StatusCode::OK, Json(json!({"items": items})))
+            let pager = build_pager(count, limit, offset, data.len() as i64);
+            (StatusCode::OK, Json(json!({"data": data, "pager": pager})))
         }
         Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "internal_error"}))),
     }

--- a/backends/rust-axum/src/infrastructure/persistence/staff.rs
+++ b/backends/rust-axum/src/infrastructure/persistence/staff.rs
@@ -51,6 +51,8 @@ fn row_to_entity(r: StaffRow) -> Staff {
     }
 }
 
+const ALLOWED_SORT: &[&str] = &["name", "role", "created_at"];
+
 /// SQLx を用いたスタッフリポジトリ実装。
 pub struct SqlxStaffRepository {
     pool: MySqlPool,
@@ -71,15 +73,9 @@ impl SqlxStaffRepository {
         .await?;
         Ok(row.map(row_to_entity))
     }
-}
 
-#[async_trait]
-impl Repository for SqlxStaffRepository {
-    async fn find_by_condition(&self, cond: Condition) -> Result<Vec<Staff>, DomainError> {
-        let mut qb: QueryBuilder<sqlx::MySql> = QueryBuilder::new(
-            "SELECT * FROM staffs WHERE 1=1"
-        );
-        if let Some(ref kw) = cond.keyword {
+    fn push_filters<'a>(qb: &mut QueryBuilder<'a, sqlx::MySql>, cond: &'a Condition) {
+        if let Some(kw) = &cond.keyword {
             if !kw.is_empty() {
                 let like = format!("%{}%", kw);
                 qb.push(" AND (name LIKE ");
@@ -97,7 +93,36 @@ impl Repository for SqlxStaffRepository {
             }
             qb.push(")");
         }
-        qb.push(" ORDER BY id ASC");
+    }
+}
+
+#[async_trait]
+impl Repository for SqlxStaffRepository {
+    async fn count_by_condition(&self, cond: Condition) -> Result<i64, DomainError> {
+        let mut qb: QueryBuilder<sqlx::MySql> = QueryBuilder::new(
+            "SELECT COUNT(*) FROM staffs WHERE 1=1"
+        );
+        SqlxStaffRepository::push_filters(&mut qb, &cond);
+        let row: (i64,) = qb.build_query_as().fetch_one(&self.pool).await?;
+        Ok(row.0)
+    }
+
+    async fn find_by_condition(&self, cond: Condition) -> Result<Vec<Staff>, DomainError> {
+        let mut qb: QueryBuilder<sqlx::MySql> = QueryBuilder::new(
+            "SELECT * FROM staffs WHERE 1=1"
+        );
+        SqlxStaffRepository::push_filters(&mut qb, &cond);
+        let sort_col = match cond.sort.as_deref() {
+            Some(s) if ALLOWED_SORT.contains(&s) => s,
+            _ => "id",
+        };
+        let sort_dir = if cond.sort_type.as_deref() == Some("desc") { "DESC" } else { "ASC" };
+        qb.push(format!(" ORDER BY {} {}", sort_col, sort_dir));
+        let limit = if cond.limit > 0 { cond.limit } else { 20 };
+        qb.push(" LIMIT ");
+        qb.push_bind(limit);
+        qb.push(" OFFSET ");
+        qb.push_bind(cond.offset);
         let rows = qb.build_query_as::<StaffRow>().fetch_all(&self.pool).await?;
         Ok(rows.into_iter().map(row_to_entity).collect())
     }

--- a/backends/rust-axum/src/usecase/auth/interactor.rs
+++ b/backends/rust-axum/src/usecase/auth/interactor.rs
@@ -155,6 +155,7 @@ mod tests {
 
     #[async_trait]
     impl Repository for MockStaffRepo {
+        async fn count_by_condition(&self, _: Condition) -> Result<i64, DomainError> { Ok(0) }
         async fn find_by_condition(&self, _: Condition) -> Result<Vec<Staff>, DomainError> { Ok(vec![]) }
         async fn find_by_id(&self, id: u32) -> Result<Option<Staff>, DomainError> {
             Ok(self.find_by_id.lock().unwrap().take().unwrap_or(Some(make_staff(id))))

--- a/backends/rust-axum/src/usecase/notification/interactor.rs
+++ b/backends/rust-axum/src/usecase/notification/interactor.rs
@@ -179,6 +179,7 @@ mod tests {
 
     #[async_trait]
     impl StaffRepository for MockStaffRepo {
+        async fn count_by_condition(&self, _: Condition) -> Result<i64, StaffDomainError> { Ok(0) }
         async fn find_by_condition(&self, _: Condition) -> Result<Vec<Staff>, StaffDomainError> { Ok(vec![]) }
         async fn find_by_id(&self, id: u32) -> Result<Option<Staff>, StaffDomainError> { Ok(Some(make_staff(id))) }
         async fn find_by_provider(&self, _: i32, _: &str) -> Result<Option<Staff>, StaffDomainError> { Ok(None) }

--- a/backends/rust-axum/src/usecase/staff/interactor.rs
+++ b/backends/rust-axum/src/usecase/staff/interactor.rs
@@ -25,10 +25,11 @@ impl Interactor {
         Self { repo }
     }
 
-    /// 検索条件に合致するスタッフ一覧の VO を返します。
-    pub async fn find_by_condition(&self, cond: Condition) -> Result<Vec<ListItem>, UseCaseError> {
+    /// 検索条件に合致するスタッフ一覧と件数を返します。
+    pub async fn find_by_condition_with_count(&self, cond: Condition) -> Result<(Vec<ListItem>, i64), UseCaseError> {
+        let count  = self.repo.count_by_condition(cond.clone()).await?;
         let staffs = self.repo.find_by_condition(cond).await?;
-        Ok(staffs.into_iter().map(to_list_item).collect())
+        Ok((staffs.into_iter().map(to_list_item).collect(), count))
     }
 
     /// スタッフのロールを更新します。楽観排他エラーまたは未存在の場合は Err を返します。
@@ -118,6 +119,9 @@ mod tests {
 
     #[async_trait]
     impl Repository for MockRepo {
+        async fn count_by_condition(&self, _cond: Condition) -> Result<i64, DomainError> {
+            Ok(self.find_by_condition.lock().unwrap().as_ref().map(|v| v.len() as i64).unwrap_or(0))
+        }
         async fn find_by_condition(&self, _cond: Condition) -> Result<Vec<Staff>, DomainError> {
             Ok(self.find_by_condition.lock().unwrap().take().unwrap_or_default())
         }
@@ -146,6 +150,10 @@ mod tests {
         }
     }
 
+    fn default_cond() -> Condition {
+        Condition { keyword: None, roles: vec![], offset: 0, limit: 20, sort: None, sort_type: None }
+    }
+
     #[tokio::test]
     async fn test_find_by_condition_maps_status() {
         let mock = Arc::new(MockRepo::new());
@@ -154,10 +162,10 @@ mod tests {
             make_staff(2, true),
         ]);
         let uc = Interactor::new(mock);
-        let result = uc.find_by_condition(Condition { keyword: None, roles: vec![] }).await.unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].status, 1);
-        assert_eq!(result[1].status, 0);
+        let (items, _count) = uc.find_by_condition_with_count(default_cond()).await.unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].status, 1);
+        assert_eq!(items[1].status, 0);
     }
 
     #[tokio::test]

--- a/backends/rust-axum/tests/integration.rs
+++ b/backends/rust-axum/tests/integration.rs
@@ -59,7 +59,8 @@ async fn get_clients_returns_list() {
 
     let body = res.into_body().collect().await.unwrap().to_bytes();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json.as_array().unwrap().len(), 2);
+    assert_eq!(json["data"].as_array().unwrap().len(), 2);
+    assert!(json["pager"].is_object());
 }
 
 #[tokio::test]

--- a/backends/rust-axum/tests/integration.rs
+++ b/backends/rust-axum/tests/integration.rs
@@ -152,7 +152,8 @@ async fn get_staffs_returns_list() {
 
     let bytes = res.into_body().collect().await.unwrap().to_bytes();
     let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-    assert_eq!(json["items"].as_array().unwrap().len(), 2);
+    assert_eq!(json["data"].as_array().unwrap().len(), 2);
+    assert!(json["pager"].is_object());
 }
 
 #[tokio::test]

--- a/backends/ts-hono/src/domain/staff/condition.ts
+++ b/backends/ts-hono/src/domain/staff/condition.ts
@@ -8,4 +8,8 @@
 export interface StaffCondition {
   keyword?: string;
   roles?: number[];
+  offset?: number;
+  limit?: number;
+  sort?: string;
+  sortType?: string;
 }

--- a/backends/ts-hono/src/domain/staff/repository.ts
+++ b/backends/ts-hono/src/domain/staff/repository.ts
@@ -5,9 +5,18 @@
  */
 import type { Staff } from "./entity.js";
 
+/** スタッフ一覧検索オプション。 */
+export interface FindAllStaffOptions {
+  offset?: number;
+  limit?: number;
+  sort?: string;
+  sortType?: string;
+}
+
 /** スタッフのリポジトリインターフェース。 */
 export interface StaffRepository {
-  findAll(keyword?: string, roles?: number[]): Promise<Staff[]>;
+  countAll(keyword?: string, roles?: number[]): Promise<number>;
+  findAll(keyword?: string, roles?: number[], options?: FindAllStaffOptions): Promise<Staff[]>;
   findById(id: number): Promise<Staff | undefined>;
   findByIdUnscoped(id: number): Promise<Staff | undefined>;
   findByProvider(provider: number, providerId: string): Promise<Staff | undefined>;

--- a/backends/ts-hono/src/infrastructure/persistence/drizzleStaffRepository.ts
+++ b/backends/ts-hono/src/infrastructure/persistence/drizzleStaffRepository.ts
@@ -3,21 +3,51 @@
  *
  * @author Satoshi Nagashiba <satoshi.nagashiba@gmail.com>
  */
-import { and, eq, inArray, isNull, like, or } from "drizzle-orm";
+import { and, asc, count as drizzleCount, desc, eq, inArray, isNull, like, or } from "drizzle-orm";
 import { staffs } from "../model/schema.js";
-import type { StaffRepository } from "../../domain/staff/repository.js";
+import type { StaffRepository, FindAllStaffOptions } from "../../domain/staff/repository.js";
 import type { Staff } from "../../domain/staff/entity.js";
 import type { DB } from "../../db/client.js";
 import { conflict } from "../../lib/errors.js";
 
+const _allowedSort: Record<string, any> = {
+  name: staffs.name,
+  role: staffs.role,
+  created_at: staffs.createdAt,
+};
+
 export class DrizzleStaffRepository implements StaffRepository {
   constructor(private readonly db: DB) {}
 
-  async findAll(keyword?: string, roles?: number[]): Promise<Staff[]> {
+  private buildWhere(keyword?: string, roles?: number[]) {
     const conds = [];
     if (keyword) conds.push(or(like(staffs.name, `%${keyword}%`), like(staffs.email, `%${keyword}%`))!);
     if (roles && roles.length > 0) conds.push(inArray(staffs.role, roles));
-    return this.db.select().from(staffs).where(conds.length ? and(...conds) : undefined).orderBy(staffs.id);
+    return conds.length ? and(...conds) : undefined;
+  }
+
+  async countAll(keyword?: string, roles?: number[]): Promise<number> {
+    const where = this.buildWhere(keyword, roles);
+    const rows = await this.db.select({ value: drizzleCount(staffs.id) }).from(staffs).where(where);
+    return rows[0]?.value ?? 0;
+  }
+
+  async findAll(keyword?: string, roles?: number[], options?: FindAllStaffOptions): Promise<Staff[]> {
+    const where = this.buildWhere(keyword, roles);
+    let q = this.db.select().from(staffs).where(where).$dynamic();
+
+    const sortCol = options?.sort ? _allowedSort[options.sort] : undefined;
+    if (sortCol) {
+      q = q.orderBy(options?.sortType === "desc" ? desc(sortCol) : asc(sortCol));
+    } else {
+      q = q.orderBy(asc(staffs.id));
+    }
+
+    if (options?.limit && options.limit > 0) {
+      q = q.limit(options.limit).offset(options.offset ?? 0);
+    }
+
+    return q;
   }
 
   async findById(id: number): Promise<Staff | undefined> {

--- a/backends/ts-hono/src/routes/staffs.ts
+++ b/backends/ts-hono/src/routes/staffs.ts
@@ -6,6 +6,7 @@
 import { Hono } from "hono";
 import { badRequest } from "../lib/errors.js";
 import { formatTime, getStaffIdFromCookie } from "../lib/cookie.js";
+import { buildPager } from "../lib/pager.js";
 import { db, asTx } from "../db/client.js";
 import { DrizzleStaffRepository } from "../infrastructure/persistence/drizzleStaffRepository.js";
 import { StaffInteractor } from "../usecase/staff/interactor.js";
@@ -24,9 +25,16 @@ app.get("/staffs", async (c) => {
   const keyword = c.req.query("keyword");
   const rolesRaw = c.req.queries("roles") ?? [];
   const roles = rolesRaw.flatMap(r => r.split(",")).map(Number).filter(n => !isNaN(n));
+  const limit = Math.max(1, parseInt(c.req.query("limit") ?? "20", 10) || 20);
+  const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10) || 1);
+  const offset = limit * (page - 1);
+  const sort = c.req.query("sort");
+  const sortType = c.req.query("sort_type");
+
   const uc = new StaffInteractor(new DrizzleStaffRepository(db));
-  const list = await uc.findByCondition(keyword, roles);
-  return c.json({ items: list.map(mapStaff) });
+  const [list, count] = await uc.findByCondition(keyword, roles, offset, limit, sort, sortType);
+  const pager = buildPager(count, limit, offset, list.length);
+  return c.json({ data: list.map(mapStaff), pager });
 });
 
 app.patch("/staffs/:id/updateRole", async (c) => {

--- a/backends/ts-hono/src/test/clients.test.ts
+++ b/backends/ts-hono/src/test/clients.test.ts
@@ -11,14 +11,15 @@ describe("Clients", () => {
       await makeClientRecord({ identifier: "c-002", email: "c2@example.com" });
       const res = await app.request("/api/clients");
       expect(res.status).toBe(200);
-      const body = await res.json() as unknown[];
-      expect(body.length).toBe(2);
+      const body = await res.json() as { data: unknown[]; pager: unknown };
+      expect(body.data.length).toBe(2);
     });
 
     test("クライアントが存在しない場合空リストを返す", async () => {
       const res = await app.request("/api/clients");
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual([]);
+      const body = await res.json() as { data: unknown[] };
+      expect(body.data).toEqual([]);
     });
   });
 
@@ -184,8 +185,8 @@ describe("Clients", () => {
       await app.request(`/api/clients/${c.id}/delete`, { method: "DELETE" });
       const res = await app.request("/api/clients");
       expect(res.status).toBe(200);
-      const body = await res.json() as unknown[];
-      expect(body.length).toBe(1);
+      const body = await res.json() as { data: unknown[] };
+      expect(body.data.length).toBe(1);
     });
 
     test("論理削除済みのクライアント詳細が取得できる", async () => {

--- a/backends/ts-hono/src/test/staffs.test.ts
+++ b/backends/ts-hono/src/test/staffs.test.ts
@@ -11,15 +11,16 @@ describe("Staffs", () => {
       await makeStaff({ email: "s2@example.com", name: "別スタッフ" });
       const res = await app.request("/api/staffs");
       expect(res.status).toBe(200);
-      const body = await res.json() as { items: unknown[] };
-      expect(body.items.length).toBe(2);
+      const body = await res.json() as { data: unknown[]; pager: unknown };
+      expect(body.data.length).toBe(2);
+      expect(body.pager).toBeDefined();
     });
 
     test("スタッフが存在しない場合空リストを返す", async () => {
       const res = await app.request("/api/staffs");
       expect(res.status).toBe(200);
-      const body = await res.json() as { items: unknown[] };
-      expect(body.items).toEqual([]);
+      const body = await res.json() as { data: unknown[] };
+      expect(body.data).toEqual([]);
     });
   });
 

--- a/backends/ts-hono/src/usecase/staff/interactor.ts
+++ b/backends/ts-hono/src/usecase/staff/interactor.ts
@@ -14,14 +14,19 @@ export class StaffInteractor {
   constructor(private readonly repo: StaffRepository) {}
 
   /**
-   * 検索条件に合致するスタッフ一覧の VO を返します。
+   * 検索条件に合致するスタッフ一覧の VO と総件数を返します。
    * @param keyword - キーワード検索
    * @param roles - ロールフィルター
-   * @returns StaffListItem の配列
+   * @param offset - オフセット
+   * @param limit - 取得件数
+   * @param sort - ソート対象
+   * @param sortType - ソート順
+   * @returns StaffListItem の配列と総件数のタプル
    */
-  async findByCondition(keyword?: string, roles?: number[]): Promise<StaffListItem[]> {
-    const staffs = await this.repo.findAll(keyword, roles);
-    return mapper.mapArray(staffs, StaffSymbol, StaffListItemSymbol);
+  async findByCondition(keyword?: string, roles?: number[], offset = 0, limit = 20, sort?: string, sortType?: string): Promise<[StaffListItem[], number]> {
+    const count = await this.repo.countAll(keyword, roles);
+    const staffs = await this.repo.findAll(keyword, roles, { offset, limit, sort, sortType });
+    return [mapper.mapArray(staffs, StaffSymbol, StaffListItemSymbol), count];
   }
 
   /**


### PR DESCRIPTION
## Summary

- Go Gin / Go Beego / Go Echo / Kotlin Ktor / Python FastAPI / TypeScript Hono / Ruby Rails / Ruby Hanami / Rust Axum の9バックエンドで GET /staffs にサーバーサイドページングを実装
- レスポンスを `{ data: [...], pager: {...} }` 形式に統一
- `offset = limit * (page - 1)` をバックエンドで内部算出
- 各バックエンドのテストを `data`/`pager` キーに合わせて更新

## Test plan

- [ ] 各バックエンドの CI が通ることを確認
- [ ] `GET /staffs?page=1&limit=10` でページング情報が返ること
- [ ] `GET /staffs?sort=name&sort_type=desc` でソートが効くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staff list endpoint now supports pagination with `limit` and `page` query parameters.
  * Sorting capability added via `sort` and `sort_type` query parameters.
  * Staff list API response updated to include pagination metadata (total count, current page information) alongside staff records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->